### PR TITLE
IA-2183 fix a bug

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val LogbackVersion = "1.2.3"
-  val workbenchGoogle2 = "0.13-e1c0c5b0-SNAP"
+  val workbenchGoogle2 = "0.13-39c1b35"
   val doobieVersion = "0.9.0"
 
   val core = Seq(
@@ -14,13 +14,13 @@ object Dependencies {
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.13.0",
     "mysql" % "mysql-connector-java" % "8.0.18",
-    "org.scalatest" %% "scalatest" % "3.2.0" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.0" % Test,
     "com.monovore" %% "decline" % "1.0.0",
     "co.fs2" %% "fs2-io" % "2.4.2",
     "com.google.cloud" % "google-cloud-dataproc" % "0.122.1",
     "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2,
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2 % "test" classifier "tests",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2 % Test classifier "tests",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test
   )
 

--- a/resource-validator/src/test/resources/reference.conf
+++ b/resource-validator/src/test/resources/reference.conf
@@ -1,8 +1,9 @@
 path-to-credential = "path-to-credential"
 
 database {
-  user = "username"
-  password = "password"
+  url = "jdbc:mysql://localhost:3311/leotestdb?createDatabaseIfNotExist=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&generateSimpleParameterMetadata=TRUE"
+  user = "leonardo-test"
+  password = "leonardo-test"
 }
 
 report-destination-bucket = "qi-test"

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderSpec.scala
@@ -1,0 +1,24 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import com.broadinstitute.dsp.DBTestHelper._
+import doobie.scalatest.IOChecker
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+
+/**
+ * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
+ * For running these tests locally, you can
+ *   * Start leonardo mysql container locally
+ *   * Comment out https://github.com/DataBiosphere/leonardo/blob/develop/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala#L82
+ *   * Run a database unit test in leonardo
+ *   * Run this spec
+ */
+@DoNotDiscover
+class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+  val transactor = yoloTransactor
+
+  it should "builds deletedDisksQuery properly" in {
+    check(DbReader.deletedDisksQuery)
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2183

In previous PR, I added `id` field to `Disk`, since we didn't have unit test, this was overlooked...I added a unit test, which people can run locally..altho running unit tests for db is not set up in CI yet

Running unit test without the fix will result in
```
  Query0[Disk] defined at DbReader.scala:24
  select pd1.googleProject, pd1.name from PERSISTENT_DISK as pd1 where
  pd1.status="Deleted" and
  NOT EXISTS
  (
  SELECT *
  FROM PERSISTENT_DISK pd2
  WHERE pd1.googleProject = pd2.googleProject and pd1.name = pd2.name
  and pd2.status != "Deleted"
  )
  ✓ SQL Compiles and TypeChecks
  ✕ C01 googleProject VARCHAR (VARCHAR) NOT NULL  →  Long
    VARCHAR (VARCHAR) is ostensibly coercible to Long according to the
    JDBC specification but is not a recommended target type. Expected
    schema type was BIGINT.
```