### PR TITLE
[no ticket] make bucket path more consistent

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
@@ -14,6 +14,8 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
 trait CheckRunner[F[_], A] {
+  def appName: String
+
   def configs: CheckRunnerConfigs
 
   def dependencies: CheckRunnerDeps[F]
@@ -30,8 +32,8 @@ trait CheckRunner[F[_], A] {
     for {
       now <- timer.clock.realTime(TimeUnit.MILLISECONDS)
       blobName = if (isDryRun)
-        GcsBlobName(s"${configs.checkType}/dry-run-${Instant.ofEpochMilli(now)}")
-      else GcsBlobName(s"${configs.checkType}/action-${Instant.ofEpochMilli(now)}")
+        GcsBlobName(s"${appName}/${configs.checkType}/dry-run-${Instant.ofEpochMilli(now)}")
+      else GcsBlobName(s"${appName}/${configs.checkType}/action-${Instant.ofEpochMilli(now)}")
       _ <- (resourceToScan
         .parEvalMapUnordered(50)(rt => checkResource(rt, isDryRun).handleErrorWith(_ => F.pure(None)))
         .unNone

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/BucketRemover.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/BucketRemover.scala
@@ -20,7 +20,8 @@ object BucketRemover {
     logger: Logger[F],
     ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, BucketToRemove] =
     new CheckRunner[F, BucketToRemove] {
-      override def configs = CheckRunnerConfigs("resource-validator/remove-staging-buckets", false)
+      override def appName: String = resourceValidator.appName
+      override def configs = CheckRunnerConfigs("remove-staging-buckets", false)
       override def dependencies: CheckRunnerDeps[F] = deps
       override def resourceToScan: fs2.Stream[F, BucketToRemove] = dbReader.getBucketsToDelete
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -14,7 +14,8 @@ object DeletedDiskChecker {
     deps: DiskCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, Disk] =
     new CheckRunner[F, Disk] {
-      override def configs = CheckRunnerConfigs("deleted-disks", true)
+      override def appName: String = resourceValidator.appName
+      override def configs = CheckRunnerConfigs(s"deleted-disks", true)
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
       override def resourceToScan: fs2.Stream[F, Disk] = dbReader.getDeletedDisks
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -17,7 +17,9 @@ object DeletedRuntimeChecker {
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, Runtime] =
     new CheckRunner[F, Runtime] {
-      override def configs = CheckRunnerConfigs("resource-validator/deleted-runtime", true)
+      override def appName: String = resourceValidator.appName
+
+      override def configs = CheckRunnerConfigs(s"deleted-runtime", true)
 
       override def dependencies: CheckRunnerDeps[F] = CheckRunnerDeps(deps.reportDestinationBucket, deps.storageService)
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
@@ -16,7 +16,8 @@ object ErroredRuntimeChecker {
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, Runtime] =
     new CheckRunner[F, Runtime] {
-      override def configs = CheckRunnerConfigs("resource-validator-errored-runtime", true)
+      override def appName: String = resourceValidator.appName
+      override def configs = CheckRunnerConfigs(s"errored-runtime", true)
       override def dependencies: CheckRunnerDeps[F] = CheckRunnerDeps(deps.reportDestinationBucket, deps.storageService)
       override def resourceToScan: fs2.Stream[F, Runtime] = dbReader.getErroredRuntimes
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/KubernetesClusterRemover.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/KubernetesClusterRemover.scala
@@ -20,7 +20,8 @@ object KubernetesClusterRemover {
     logger: Logger[F],
     ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, KubernetesClusterId] =
     new CheckRunner[F, KubernetesClusterId] {
-      override def configs = CheckRunnerConfigs("remove-staging-buckets", true)
+      override def appName: String = resourceValidator.appName
+      override def configs = CheckRunnerConfigs(s"remove-kubernetes-clusters", true)
       override def dependencies: CheckRunnerDeps[F] = deps
       override def resourceToScan: fs2.Stream[F, KubernetesClusterId] = dbReader.getK8sClustersToDelete
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/package.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/package.scala
@@ -1,0 +1,5 @@
+package com.broadinstitute.dsp
+
+package object resourceValidator {
+  val appName = "resource-validator"
+}

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -20,7 +20,7 @@ object DeletedDiskChecker {
     new CheckRunner[F, Disk] {
       override def resourceToScan: Stream[F, Disk] = dbReader.getDisksToDeleteCandidate
 
-      override def configs = CheckRunnerConfigs("zombie-monitor/deleted-disk", false)
+      override def configs = CheckRunnerConfigs(s"deleted-disk", false)
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 
@@ -34,5 +34,7 @@ object DeletedDiskChecker {
               case Some(_) => F.unit
             }
         } yield diskOpt.fold[Option[Disk]](Some(disk))(_ => none[Disk])
+
+      override def appName: String = zombieMonitor.appName
     }
 }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -22,7 +22,7 @@ object DeletedKubernetesClusterChecker {
 
       override def resourceToScan: Stream[F, K8sClusterToScan] = dbReader.getk8sClustersToDeleteCandidate
 
-      override def configs = CheckRunnerConfigs(s"${appName}/deleted-kubernetes", false)
+      override def configs = CheckRunnerConfigs(s"deleted-kubernetes", false)
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -18,9 +18,11 @@ object DeletedKubernetesClusterChecker {
     deps: KubernetesClusterCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, K8sClusterToScan] =
     new CheckRunner[F, K8sClusterToScan] {
+      override def appName: String = zombieMonitor.appName
+
       override def resourceToScan: Stream[F, K8sClusterToScan] = dbReader.getk8sClustersToDeleteCandidate
 
-      override def configs = CheckRunnerConfigs("zombie-monitor/deleted-kubernetes", false)
+      override def configs = CheckRunnerConfigs(s"${appName}/deleted-kubernetes", false)
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/package.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/package.scala
@@ -1,0 +1,5 @@
+package com.broadinstitute.dsp
+
+package object zombieMonitor {
+  val appName = "zombie-monitor"
+}


### PR DESCRIPTION
previously we weren't very consistent in terms of where reports will be sent to. This PR makes it more consistent.

All reports generated from resource-validator will be under
`leonardo-resource-validator-report-{env}/resource-validator/${check-type}/???`

All reports generated from zombie-monitor will be under
`leonardo-resource-validator-report-{env}/zombie-monitor/${check-type}/???`


We should probably rename the bucket name itself as well since we split things into multiple cron jobs..But that refactoring will require more changes, we can do it another time