### PR TITLE
[no ticket] fix bug

### DIFF
--- a/resource-validator/src/main/resources/reference.conf
+++ b/resource-validator/src/main/resources/reference.conf
@@ -9,3 +9,8 @@ database {
 leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
+
+runtime-checker-config {
+  path-to-credential = ${path-to-credential}
+  report-destination-bucket = ${report-destination-bucket}
+}

--- a/resource-validator/src/test/resources/reference.conf
+++ b/resource-validator/src/test/resources/reference.conf
@@ -11,8 +11,3 @@ report-destination-bucket = "test-bucket"
 leonardo-pubsub {
   google-project = "test-project"
 }
-
-runtime-checker-config {
-  path-to-credential = ${path-to-credential}
-  report-destination-bucket = ${report-destination-bucket}
-}


### PR DESCRIPTION
`runtime-checker-config` is needed, but I accidentally added to the `reference.conf` in test, hence unit test is working fine, but it's actually missing for resource-validator