### PR TITLE
fix config bug

### DIFF
--- a/resource-validator/src/main/resources/reference.conf
+++ b/resource-validator/src/main/resources/reference.conf
@@ -10,6 +10,8 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
+report-destination-bucket = "replace-me"
+
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}

--- a/zombie-monitor/src/main/resources/reference.conf
+++ b/zombie-monitor/src/main/resources/reference.conf
@@ -6,7 +6,7 @@ database {
   password = ${LEONARDO_DB_PASSWORD}
 }
 
-report-destination-bucket = ${REPORT_DESTINATION_BUCKET}
+report-destination-bucket = "replace-me"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}


### PR DESCRIPTION
Since `report-destination-bucket` is referenced by another config in reference.conf, it needs to be present in reference.conf. Its actual value will be replaced by config file passed by `-D`..I think leonardo uses the same pattern as well

Tested in my own namespace