### PR TITLE
[IA-2270] Delete deleted and errored k8s clusters and nodepools in Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ e.g. `sbt "resourceValidator/run --dryRun --all"`
 
 Currently, `com.broadinstitute.dsp.zombieMonitor.DbReaderSpec` and `com.broadinstitute.dsp.resourceValidator.DbReaderSpec` are not run in CI, hence make sure you run them manually before merging any PRs.
 
-Once a PR is merged, there will be a PR created in [terra-helm](https://github.com/broadinstitute/terra-helm) (WIP). 
+Once a PR is merged, there will be a PR created in [terra-helm](https://github.com/broadinstitute/terra-helm). 
 Get this PR merged, and another automatic commit will bump leonardo's chart version. This will trigger another automatic commit 
 in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile), note this commit will only auto bump `dev` and `perf`,
 create another PR for bumping all other environments when you're ready (similar to [this](https://github.com/broadinstitute/terra-helmfile/pull/390)). Once all these PRs are merged, 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run \
   -instances=<mysql instance you'd like to connect> -credential_file=/config
 ```
 
-## Copy `application.conf.example` under each project as `application.conf`. Replace values properly
+## Copy `application.conf.example` under each project in dir `[project]/src/main/resources` as `application.conf`. Replace values properly
 
 ## Run a job
 ```

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -1,7 +1,12 @@
 package com.broadinstitute.dsp
 
-import org.broadinstitute.dsde.workbench.google2.DiskName
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolId}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, Location}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{
+  KubernetesClusterId,
+  KubernetesClusterName,
+  NodepoolId,
+  NodepoolName
+}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
 sealed abstract class CloudService extends Product with Serializable {
@@ -38,3 +43,15 @@ final case class K8sClusterToScan(id: Long, kubernetesClusterId: KubernetesClust
 final case class NodepoolToScan(id: Long, nodepoolId: NodepoolId)
 
 final case class KubernetesClusterToRemove(id: Long, googleProject: GoogleProject)
+
+final case class KubernetesCluster(clusterName: KubernetesClusterName,
+                                   googleProject: GoogleProject,
+                                   location: Location) {
+  override def toString: String = s"${clusterName}/${googleProject}"
+}
+final case class Nodepool(nodepoolName: NodepoolName,
+                          clusterName: KubernetesClusterName,
+                          googleProject: GoogleProject,
+                          location: Location) {
+  override def toString: String = s"${nodepoolName}/${googleProject}"
+}

--- a/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
@@ -172,6 +172,16 @@ object DBTestHelper {
          SELECT errorCode, errorMessage FROM CLUSTER_ERROR where clusterId = ${runtimeId}
          """.query[RuntimeError].unique.transact(xa)
 
+  def getK8sClusterName(id: Long)(implicit xa: HikariTransactor[IO]): IO[String] =
+    sql"""
+         SELECT clusterName FROM KUBERNETES_CLUSTER where id = ${id}
+         """.query[String].unique.transact(xa)
+
+  def getNodepoolName(id: Long)(implicit xa: HikariTransactor[IO]): IO[String] =
+    sql"""
+         SELECT nodepoolName FROM NODEPOOL where id = ${id}
+         """.query[String].unique.transact(xa)
+
   private def truncateTables(xa: HikariTransactor[IO]): IO[Unit] = {
     val res = for {
       _ <- sql"Delete from APP".update.run

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val LogbackVersion = "1.2.3"
-  val workbenchGoogle2 = "0.13-39c1b35"
+  val workbenchGoogle2 = "0.14-aed2645"
   val doobieVersion = "0.9.0"
   val openTelemetryVersion = "0.1-e66171c"
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
@@ -1,0 +1,49 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import cats.effect.{Concurrent, Timer}
+import cats.implicits._
+import cats.mtl.ApplicativeAsk
+import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
+import org.broadinstitute.dsde.workbench.model.TraceId
+
+object DeletedOrErroredKubernetesClusterChecker {
+  def impl[F[_]: Timer](
+    dbReader: DbReader[F],
+    deps: KubernetesClusterCheckerDeps[F]
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, KubernetesCluster] =
+    new CheckRunner[F, KubernetesCluster] {
+      override def appName: String = resourceValidator.appName
+
+      override def configs = CheckRunnerConfigs(s"deleted-kubernetes-clusters", shouldAlert = true)
+
+      override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+
+      override def checkResource(cluster: KubernetesCluster, isDryRun: Boolean)(
+        implicit ev: ApplicativeAsk[F, TraceId]
+      ): F[Option[KubernetesCluster]] = checkKubernetesClusterStatus(cluster, isDryRun)
+
+      override def resourceToScan: fs2.Stream[F, KubernetesCluster] = dbReader.getDeletedAndErroredKubernetesClusters
+
+      def checkKubernetesClusterStatus(cluster: KubernetesCluster, isDryRun: Boolean)(
+        implicit ev: ApplicativeAsk[F, TraceId]
+      ): F[Option[KubernetesCluster]] =
+        for {
+          clusterOpt <- deps.gkeService.getCluster(
+            KubernetesClusterId(cluster.googleProject, cluster.location, cluster.clusterName)
+          )
+          _ <- clusterOpt.traverse_ { _ =>
+            if (isDryRun) {
+              logger.warn(s"${cluster.toString} still exists in Google. It needs to be deleted")
+            } else {
+              logger.warn(s"${cluster.toString} still exists in Google. Going to delete") >> deps.gkeService
+                .deleteCluster(
+                  KubernetesClusterId(cluster.googleProject, cluster.location, cluster.clusterName)
+                )
+                .void
+            }
+          }
+        } yield clusterOpt.fold(none[KubernetesCluster])(_ => Some(cluster))
+    }
+}

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
@@ -1,0 +1,50 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import cats.effect.{Concurrent, Timer}
+import cats.implicits._
+import cats.mtl.ApplicativeAsk
+import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolId}
+import org.broadinstitute.dsde.workbench.model.TraceId
+
+object DeletedOrErroredNodepoolChecker {
+  def impl[F[_]: Timer](
+    dbReader: DbReader[F],
+    deps: KubernetesClusterCheckerDeps[F]
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: ApplicativeAsk[F, TraceId]): CheckRunner[F, Nodepool] =
+    new CheckRunner[F, Nodepool] {
+      override def appName: String = resourceValidator.appName
+
+      override def configs = CheckRunnerConfigs(s"deleted-nodepools", shouldAlert = true)
+
+      override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+
+      override def checkResource(nodepool: Nodepool, isDryRun: Boolean)(
+        implicit ev: ApplicativeAsk[F, TraceId]
+      ): F[Option[Nodepool]] = checkNodepoolStatus(nodepool, isDryRun)
+
+      override def resourceToScan: fs2.Stream[F, Nodepool] = dbReader.getDeletedAndErroredNodepools
+
+      def checkNodepoolStatus(nodepool: Nodepool,
+                              isDryRun: Boolean)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Nodepool]] =
+        for {
+          nodepoolOpt <- deps.gkeService.getNodepool(
+            NodepoolId(KubernetesClusterId(nodepool.googleProject, nodepool.location, nodepool.clusterName),
+                       nodepool.nodepoolName)
+          )
+          _ <- nodepoolOpt.traverse_ { _ =>
+            if (isDryRun) {
+              logger.warn(s"${nodepool.toString} still exists in Google. It needs to be deleted")
+            } else {
+              logger.warn(s"${nodepool.toString} still exists in Google. Going to delete") >> deps.gkeService
+                .deleteNodepool(
+                  NodepoolId(KubernetesClusterId(nodepool.googleProject, nodepool.location, nodepool.clusterName),
+                             nodepool.nodepoolName)
+                )
+                .void
+            }
+          }
+        } yield nodepoolOpt.fold(none[Nodepool])(_ => Some(nodepool))
+    }
+}

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
@@ -22,26 +22,38 @@ object Main
         val shouldRunCheckDeletedDisks = Opts.flag("checkDeletedDisks", "check all deleted disks").orFalse
         val shouldRunCheckInitBuckets =
           Opts.flag("checkInitBuckets", "checks that init buckets for deleted runtimes are deleted").orFalse
+        val shouldRunCheckDeletedKubernetesClusters =
+          Opts.flag("checkDeletedKubernetesClusters", "check all deleted or errored kubernetes clusters").orFalse
+        val shouldRunCheckDeletedNodepools =
+          Opts.flag("checkDeletedNodepools", "check all deleted or errored nodepools").orFalse
 
         (enableDryRun,
          shouldRunAll,
          shouldRunCheckDeletedRuntimes,
          shouldRunCheckErroredRuntimes,
          shouldRunCheckDeletedDisks,
-         shouldRunCheckInitBuckets).mapN {
+         shouldRunCheckInitBuckets,
+         shouldRunCheckDeletedKubernetesClusters,
+         shouldRunCheckDeletedNodepools).mapN {
           (dryRun,
            runAll,
            shouldCheckDeletedRuntimes,
            shouldRunCheckErroredRuntimes,
            shouldRunCheckDeletedDisks,
-           shouldRunCheckInitBuckets) =>
+           shouldRunCheckInitBuckets,
+           shouldRunCheckDeletedKubernetesClusters,
+           shouldRunCheckDeletedNodepools) =>
             ResourceValidator
-              .run[IO](dryRun,
-                       runAll,
-                       shouldCheckDeletedRuntimes,
-                       shouldRunCheckErroredRuntimes,
-                       shouldRunCheckDeletedDisks,
-                       shouldRunCheckInitBuckets)
+              .run[IO](
+                isDryRun = dryRun,
+                shouldRunAll = runAll,
+                shouldRunCheckDeletedRuntimes = shouldCheckDeletedRuntimes,
+                shouldRunCheckErroredRuntimes = shouldRunCheckErroredRuntimes,
+                shouldRunCheckDeletedDisks = shouldRunCheckDeletedDisks,
+                shouldRunCheckInitBuckets = shouldRunCheckInitBuckets,
+                shouldRunCheckDeletedKubernetesCluster = shouldRunCheckDeletedKubernetesClusters,
+                shouldRunCheckDeletedNodepool = shouldRunCheckDeletedNodepools
+              )
               .compile
               .drain
               .unsafeRunSync()

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
@@ -1,0 +1,49 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import com.broadinstitute.dsp.DBTestHelper._
+import doobie.scalatest.IOChecker
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+
+/**
+ * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
+ * For running these tests locally, you can
+ *   * Start leonardo mysql container locally
+ *   * Comment out https://github.com/DataBiosphere/leonardo/blob/develop/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala#L82
+ *   * Run a database unit test in leonardo
+ *   * Run this spec
+ */
+@DoNotDiscover
+class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+  implicit val config = ConfigSpec.config.database
+  val transactor = yoloTransactor
+
+  it should "build deletedDisksQuery properly" in {
+    check(DbReader.deletedDisksQuery)
+  }
+
+  it should "build initBucketsToDeleteQuery properly" in {
+    check(DbReader.initBucketsToDeleteQuery)
+  }
+
+  it should "build deletedRuntimeQuery properly" in {
+    check(DbReader.deletedRuntimeQuery)
+  }
+
+  it should "build erroredRuntimeQuery properly" in {
+    check(DbReader.erroredRuntimeQuery)
+  }
+
+  it should "build kubernetesClustersToDeleteQuery properly" in {
+    check(DbReader.kubernetesClustersToDeleteQuery)
+  }
+
+  it should "build deletedAndErroredKubernetesClusterQuery properly" in {
+    check(DbReader.deletedAndErroredKubernetesClusterQuery)
+  }
+
+  it should "build deletedAndErroredNodepoolQuery properly" in {
+    check(DbReader.deletedAndErroredNodepoolQuery)
+  }
+}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -1,0 +1,53 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import com.broadinstitute.dsp.DBTestHelper.{insertK8sCluster, _}
+import com.broadinstitute.dsp.Generators._
+import doobie.scalatest.IOChecker
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+
+@DoNotDiscover
+class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+  implicit val config = ConfigSpec.config.database
+  val transactor = yoloTransactor
+
+  it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" in {
+    forAll { (cluster: KubernetesClusterId) =>
+      val res = transactorResource.use { implicit xa =>
+        val dbReader = DbReader.impl(xa)
+
+        val cluster2 =
+          cluster.copy(project = GoogleProject("project2"))
+        val cluster3 =
+          cluster.copy(project = GoogleProject("project3"))
+        val cluster4 =
+          cluster.copy(project = GoogleProject("project4"))
+        val cluster5 =
+          cluster.copy(project = GoogleProject("project5"))
+        val cluster6 =
+          cluster.copy(project = GoogleProject("project6"))
+
+        for {
+          cluster1Id <- insertK8sCluster(cluster, "DELETED")
+          cluster2Id <- insertK8sCluster(cluster2, "DELETED")
+          cluster3Id <- insertK8sCluster(cluster3, "ERROR")
+          _ <- insertK8sCluster(cluster4, "RUNNING")
+          _ <- insertK8sCluster(cluster5, "PROVISIONING")
+          _ <- insertK8sCluster(cluster6, "PRE-CREATING")
+
+          cluster1Name <- getK8sClusterName(cluster1Id)
+          cluster2Name <- getK8sClusterName(cluster2Id)
+          cluster3Name <- getK8sClusterName(cluster3Id)
+
+          clustersToDelete <- dbReader.getDeletedAndErroredKubernetesClusters.compile.toList
+        } yield clustersToDelete.map(_.clusterName) shouldBe List(KubernetesClusterName(cluster1Name),
+                                                                  KubernetesClusterName(cluster2Name),
+                                                                  KubernetesClusterName(cluster3Name))
+      }
+      res.unsafeRunSync()
+    }
+  }
+}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -1,0 +1,53 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import com.broadinstitute.dsp.DBTestHelper.{
+  getNodepoolName,
+  insertK8sCluster,
+  insertNodepool,
+  transactorResource,
+  yoloTransactor
+}
+import com.broadinstitute.dsp.Generators._
+import doobie.scalatest.IOChecker
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.scalatest.DoNotDiscover
+import org.scalatest.flatspec.AnyFlatSpec
+
+@DoNotDiscover
+class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+  implicit val config = ConfigSpec.config.database
+  val transactor = yoloTransactor
+
+  it should "detect nodepools that are Deleted or Errored in the Leo DB" in {
+    forAll { (cluster: KubernetesClusterId) =>
+      val res = transactorResource.use { implicit xa =>
+        val dbReader = DbReader.impl(xa)
+
+        val cluster2 =
+          cluster.copy(project = GoogleProject("project2"))
+
+        for {
+          clusterId <- insertK8sCluster(cluster)
+          cluster2Id <- insertK8sCluster(cluster2)
+          nodepool1Id <- insertNodepool(clusterId, "nodepool1", true, "DELETED")
+          nodepool2Id <- insertNodepool(cluster2Id, "nodepool2", true, "ERROR")
+          nodepool3Id <- insertNodepool(cluster2Id, "nodepool3", true, "ERROR")
+          _ <- insertNodepool(clusterId, "nodepool4", true, "RUNNING")
+          _ <- insertNodepool(cluster2Id, "nodepool5", true, "PROVISIONING")
+          _ <- insertNodepool(clusterId, "nodepool6", true, "PREDELETING")
+
+          nodepool1Name <- getNodepoolName(nodepool1Id)
+          nodepool2Name <- getNodepoolName(nodepool2Id)
+          nodepool3Name <- getNodepoolName(nodepool3Id)
+
+          clustersToDelete <- dbReader.getDeletedAndErroredNodepools.compile.toList
+        } yield clustersToDelete.map(_.nodepoolName) shouldBe List(NodepoolName(nodepool1Name),
+                                                                   NodepoolName(nodepool2Name),
+                                                                   NodepoolName(nodepool3Name))
+      }
+      res.unsafeRunSync()
+    }
+  }
+}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -20,31 +20,10 @@ import org.scalatest.flatspec.AnyFlatSpec
  *   * Run this spec
  */
 @DoNotDiscover
-class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 
-  it should "build deletedDisksQuery properly" in {
-    check(DbReader.deletedDisksQuery)
-  }
-
-  it should "build initBucketsToDeleteQuery properly" in {
-    check(DbReader.initBucketsToDeleteQuery)
-  }
-
-  it should "build deletedRuntimeQuery properly" in {
-    check(DbReader.deletedRuntimeQuery)
-  }
-
-  it should "build erroredRuntimeQuery properly" in {
-    check(DbReader.erroredRuntimeQuery)
-  }
-
-  it should "build kubernetesClustersToDeleteQuery properly" in {
-    check(DbReader.kubernetesClustersToDeleteQuery)
-  }
-
-  // TODO: Rename this file as 'DbQueryBuilderSpec' and move the checker-functionality-specific tests below to their own Spec(s)
   val now = Instant.now()
   val gracePeriod = 3600 // in seconds
 

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
@@ -1,0 +1,62 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import cats.effect.IO
+import cats.mtl.ApplicativeAsk
+import com.broadinstitute.dsp.Generators._
+import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initKubernetesClusterCheckerDeps
+import com.google.container.v1.{Cluster, Operation}
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
+import org.broadinstitute.dsde.workbench.google2.mock.MockGKEService
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
+  it should "return None if kubernetes cluster no longer exists in Google" in {
+    val gkeService = new MockGKEService {
+      override def getCluster(clusterId: KubernetesClusterId)(
+        implicit ev: ApplicativeAsk[IO, TraceId]
+      ): IO[Option[Cluster]] = IO.pure(None)
+    }
+
+    val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
+
+    forAll { (cluster: KubernetesCluster, dryRun: Boolean) =>
+      val dbReader = new FakeDbReader {
+        override def getDeletedAndErroredKubernetesClusters: fs2.Stream[IO, KubernetesCluster] = Stream.emit(cluster)
+      }
+      val deletedOrErroredKubernetesClusterChecker =
+        DeletedOrErroredKubernetesClusterChecker.impl(dbReader, deps)
+      val res = deletedOrErroredKubernetesClusterChecker.checkResource(cluster, dryRun)
+      res.unsafeRunSync() shouldBe None
+    }
+  }
+
+  it should "return KubernetesCluster if cluster still exists in Google" in {
+    forAll { (cluster: KubernetesCluster, dryRun: Boolean) =>
+      val dbReader = new FakeDbReader {
+        override def getDeletedAndErroredKubernetesClusters: fs2.Stream[IO, KubernetesCluster] = Stream.emit(cluster)
+      }
+      val gkeService = new MockGKEService {
+        override def getCluster(clusterId: KubernetesClusterId)(
+          implicit ev: ApplicativeAsk[IO, TraceId]
+        ): IO[Option[Cluster]] = {
+          val cluster = Cluster.newBuilder().build()
+          IO.pure(Some(cluster))
+        }
+
+        override def deleteCluster(clusterId: KubernetesClusterId)(
+          implicit ev: ApplicativeAsk[IO, TraceId]
+        ): IO[Option[Operation]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(Some(Operation.newBuilder().build()))
+      }
+
+      val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
+
+      val deletedOrErroredKubernetesClusterChecker = DeletedOrErroredKubernetesClusterChecker.impl(dbReader, deps)
+      val res = deletedOrErroredKubernetesClusterChecker.checkResource(cluster, dryRun)
+      res.unsafeRunSync() shouldBe Some(cluster)
+    }
+  }
+}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -1,0 +1,62 @@
+package com.broadinstitute.dsp
+package resourceValidator
+
+import cats.effect.IO
+import cats.mtl.ApplicativeAsk
+import com.broadinstitute.dsp.Generators._
+import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initKubernetesClusterCheckerDeps
+import com.google.container.v1.{NodePool, Operation}
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolId
+import org.broadinstitute.dsde.workbench.google2.mock.MockGKEService
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
+  it should "return None if nodepool no longer exists in Google" in {
+    val gkeService = new MockGKEService {
+      override def getNodepool(nodepoolId: NodepoolId)(
+        implicit ev: ApplicativeAsk[IO, TraceId]
+      ): IO[Option[NodePool]] = IO.pure(None)
+    }
+
+    val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
+
+    forAll { (nodepool: Nodepool, dryRun: Boolean) =>
+      val dbReader = new FakeDbReader {
+        override def getDeletedAndErroredNodepools: fs2.Stream[IO, Nodepool] = Stream.emit(nodepool)
+      }
+      val deletedOrErroredNodepoolChecker =
+        DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
+      val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
+      res.unsafeRunSync() shouldBe None
+    }
+  }
+
+  it should "return nodepool if nodepool still exists in Google" in {
+    forAll { (nodepool: Nodepool, dryRun: Boolean) =>
+      val dbReader = new FakeDbReader {
+        override def getDeletedAndErroredNodepools: fs2.Stream[IO, Nodepool] = Stream.emit(nodepool)
+      }
+      val gkeService = new MockGKEService {
+        override def getNodepool(nodepoolId: NodepoolId)(
+          implicit ev: ApplicativeAsk[IO, TraceId]
+        ): IO[Option[NodePool]] = {
+          val nodepool = NodePool.newBuilder().build()
+          IO.pure(Some(nodepool))
+        }
+
+        override def deleteNodepool(nodepoolId: NodepoolId)(
+          implicit ev: ApplicativeAsk[IO, TraceId]
+        ): IO[Option[Operation]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(Some(Operation.newBuilder().build()))
+      }
+
+      val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
+
+      val deletedOrErroredNodepoolChecker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
+      val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
+      res.unsafeRunSync() shouldBe Some(nodepool)
+    }
+  }
+}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
@@ -1,12 +1,18 @@
 package com.broadinstitute.dsp.resourceValidator
 
 import cats.effect.IO
-import com.broadinstitute.dsp.{CheckRunnerDeps, RuntimeCheckerDeps}
-import org.broadinstitute.dsde.workbench.google2.{GoogleComputeService, GoogleDataprocService, GoogleStorageService}
+import com.broadinstitute.dsp.{CheckRunnerDeps, KubernetesClusterCheckerDeps, RuntimeCheckerDeps}
+import org.broadinstitute.dsde.workbench.google2.{
+  GKEService,
+  GoogleComputeService,
+  GoogleDataprocService,
+  GoogleStorageService
+}
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   FakeGoogleDataprocService,
-  FakeGoogleStorageInterpreter
+  FakeGoogleStorageInterpreter,
+  MockGKEService
 }
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 
@@ -20,5 +26,12 @@ object InitDependenciesHelper {
       googleComputeService,
       googleDataprocService,
       CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter)
+    )
+
+  def initKubernetesClusterCheckerDeps(gkeService: GKEService[IO] = MockGKEService,
+                                       googleStorageService: GoogleStorageService[IO] = FakeGoogleStorageInterpreter) =
+    KubernetesClusterCheckerDeps(
+      CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter),
+      gkeService
     )
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/mocks.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/mocks.scala
@@ -19,6 +19,10 @@ class FakeDbReader extends DbReader[IO] {
   override def getDeletedDisks: Stream[IO, Disk] = Stream.empty
 
   override def getInitBucketsToDelete: Stream[IO, InitBucketToRemove] = Stream.empty
+
+  override def getDeletedAndErroredKubernetesClusters: Stream[IO, KubernetesCluster] = Stream.empty
+
+  override def getDeletedAndErroredNodepools: Stream[IO, Nodepool] = Stream.empty
 }
 
 class FakeGooglePublisher extends GooglePublisher[IO] {


### PR DESCRIPTION
Tested using unit tests and also running the two new checkers (for KubernetesClusters and Nodepools) locally and seeing that nodepool anomalies were detected in google project `broad-dsde-dev` and verified that these anomalies were indeed marked as `ERROR` in the leo db but still existed in google