### PR TITLE
[IA-2347] ResourceValidator publishes DeleteNodepoolMessage

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.workbench.google2.{
   GoogleComputeService,
   GoogleDataprocService,
   GoogleDiskService,
+  GooglePublisher,
   GoogleStorageService
 }
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
@@ -59,6 +60,10 @@ final case class RuntimeCheckerDeps[F[_]](computeService: GoogleComputeService[F
                                           checkRunnerDeps: CheckRunnerDeps[F])
 
 final case class KubernetesClusterCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F], gkeService: GKEService[F])
+
+final case class NodepoolCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F],
+                                           gkeService: GKEService[F],
+                                           publisher: GooglePublisher[F])
 
 final case class DiskCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F], googleDiskService: GoogleDiskService[F])
 

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -49,7 +49,8 @@ final case class KubernetesCluster(clusterName: KubernetesClusterName,
                                    location: Location) {
   override def toString: String = s"${clusterName}/${googleProject}"
 }
-final case class Nodepool(nodepoolName: NodepoolName,
+final case class Nodepool(nodepoolId: Long,
+                          nodepoolName: NodepoolName,
                           clusterName: KubernetesClusterName,
                           googleProject: GoogleProject,
                           location: Location) {

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -31,11 +31,12 @@ object Generators {
   } yield KubernetesCluster(name, project, location)
 
   val genNodepool: Gen[Nodepool] = for {
+    id <- Gen.chooseNum(0, 100)
     nodepoolName <- genNodepoolName
     clusterName <- Gen.uuid.map(x => KubernetesClusterName(x.toString))
     project <- genGoogleProject
     location <- genLocation
-  } yield Nodepool(nodepoolName, clusterName, project, location)
+  } yield Nodepool(id, nodepoolName, clusterName, project, location)
 
   val genK8sClusterToScan: Gen[K8sClusterToScan] = for {
     id <- Gen.chooseNum(0, 100)

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -93,7 +93,7 @@ object DbReader {
       .query[KubernetesCluster]
 
   val deletedAndErroredNodepoolQuery =
-    sql"""SELECT np.nodepoolName, kc.clusterName, kc.googleProject, kc.location
+    sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.googleProject, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
          WHERE np.status="DELETED" OR np.status="ERROR"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
@@ -1,18 +1,28 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import java.util.concurrent.TimeUnit
+
 import cats.effect.{Concurrent, Timer}
 import cats.implicits._
+import io.circe.Encoder
 import cats.mtl.Ask
 import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolId}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}
 
 object DeletedOrErroredNodepoolChecker {
+  implicit val deleteNodepoolMessageEncoder: Encoder[DeleteNodepoolMeesage] =
+    Encoder.forProduct4("messageType", "nodepoolId", "googleProject", "traceId")(x =>
+      (x.messageType, x.nodepoolId, x.googleProject, x.traceId)
+    )
+
   def impl[F[_]: Timer](
     dbReader: DbReader[F],
-    deps: KubernetesClusterCheckerDeps[F]
-  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Nodepool] =
+    deps: NodepoolCheckerDeps[F]
+  )(implicit F: Concurrent[F], timer: Timer[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Nodepool] =
     new CheckRunner[F, Nodepool] {
       override def appName: String = resourceValidator.appName
 
@@ -29,6 +39,7 @@ object DeletedOrErroredNodepoolChecker {
       def checkNodepoolStatus(nodepool: Nodepool,
                               isDryRun: Boolean)(implicit ev: Ask[F, TraceId]): F[Option[Nodepool]] =
         for {
+          now <- timer.clock.realTime(TimeUnit.MILLISECONDS)
           nodepoolOpt <- deps.gkeService.getNodepool(
             NodepoolId(KubernetesClusterId(nodepool.googleProject, nodepool.location, nodepool.clusterName),
                        nodepool.nodepoolName)
@@ -37,14 +48,18 @@ object DeletedOrErroredNodepoolChecker {
             if (isDryRun) {
               logger.warn(s"${nodepool.toString} still exists in Google. It needs to be deleted")
             } else {
-              logger.warn(s"${nodepool.toString} still exists in Google. Going to delete") >> deps.gkeService
-                .deleteNodepool(
-                  NodepoolId(KubernetesClusterId(nodepool.googleProject, nodepool.location, nodepool.clusterName),
-                             nodepool.nodepoolName)
-                )
-                .void
+              val msg = DeleteNodepoolMeesage(nodepool.nodepoolId,
+                                              nodepool.googleProject,
+                                              Some(TraceId(s"DeletedOrErroredNodepoolChecker-$now")))
+              logger.warn(s"${nodepool.toString} still exists in Google. Going to delete") >> deps.publisher.publishOne(
+                msg
+              )
             }
           }
         } yield nodepoolOpt.fold(none[Nodepool])(_ => Some(nodepool))
     }
+}
+
+final case class DeleteNodepoolMeesage(nodepoolId: Long, googleProject: GoogleProject, traceId: Option[TraceId]) {
+  val messageType: String = "deleteNodepool"
 }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
@@ -54,7 +54,7 @@ object ResourceValidator {
       else Stream.empty
       deleteNodepoolCheckerProcess = if (shouldCheckAll || shouldCheckDeletedNodepool)
         Stream.eval(
-          DeletedOrErroredNodepoolChecker.impl(deps.dbReader, deps.kubernetesClusterCheckerDeps).run(isDryRun)
+          DeletedOrErroredNodepoolChecker.impl(deps.dbReader, deps.nodepoolCheckerDeps).run(isDryRun)
         )
       else Stream.empty
 
@@ -111,11 +111,13 @@ object ResourceValidator {
       val diskCheckerDeps = DiskCheckerDeps(checkRunnerDeps, diskService)
       val kubernetesClusterToRemoveDeps = KubernetesClusterRemoverDeps(googlePublisher, checkRunnerDeps)
       val kubernetesClusterCheckerDeps = KubernetesClusterCheckerDeps(checkRunnerDeps, gkeService)
+      val nodepoolCheckerDeps = NodepoolCheckerDeps(checkRunnerDeps, gkeService, googlePublisher)
       val dbReader = DbReader.impl(xa)
       ResourcevalidatorServerDeps(runtimeCheckerDeps,
                                   diskCheckerDeps,
                                   kubernetesClusterToRemoveDeps,
                                   kubernetesClusterCheckerDeps,
+                                  nodepoolCheckerDeps,
                                   dbReader,
                                   blocker)
     }
@@ -126,6 +128,7 @@ final case class ResourcevalidatorServerDeps[F[_]](
   deletedDiskCheckerDeps: DiskCheckerDeps[F],
   kubernetesClusterRemoverDeps: KubernetesClusterRemoverDeps[F],
   kubernetesClusterCheckerDeps: KubernetesClusterCheckerDeps[F],
+  nodepoolCheckerDeps: NodepoolCheckerDeps[F],
   dbReader: DbReader[F],
   blocker: Blocker
 )

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -4,40 +4,23 @@ package resourceValidator
 import cats.effect.IO
 import cats.mtl.Ask
 import com.broadinstitute.dsp.Generators._
-import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initKubernetesClusterCheckerDeps
-import com.google.container.v1.{NodePool, Operation}
+import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initNodepoolCheckerDeps
 import fs2.Stream
+import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolId
-import org.broadinstitute.dsde.workbench.google2.mock.MockGKEService
+import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, MockGKEService}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import com.google.container.v1.NodePool
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "return None if nodepool no longer exists in Google" in {
-    val gkeService = new MockGKEService {
-      override def getNodepool(nodepoolId: NodepoolId)(
-        implicit ev: Ask[IO, TraceId]
-      ): IO[Option[NodePool]] = IO.pure(None)
-    }
 
-    val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
-
+  it should "not publish to subscriber if dryRun" in {
     forAll { (nodepool: Nodepool, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getDeletedAndErroredNodepools: fs2.Stream[IO, Nodepool] = Stream.emit(nodepool)
       }
-      val deletedOrErroredNodepoolChecker =
-        DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
-      val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
-      res.unsafeRunSync() shouldBe None
-    }
-  }
 
-  it should "return nodepool if nodepool still exists in Google" in {
-    forAll { (nodepool: Nodepool, dryRun: Boolean) =>
-      val dbReader = new FakeDbReader {
-        override def getDeletedAndErroredNodepools: fs2.Stream[IO, Nodepool] = Stream.emit(nodepool)
-      }
       val gkeService = new MockGKEService {
         override def getNodepool(nodepoolId: NodepoolId)(
           implicit ev: Ask[IO, TraceId]
@@ -45,18 +28,28 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
           val nodepool = NodePool.newBuilder().build()
           IO.pure(Some(nodepool))
         }
-
-        override def deleteNodepool(nodepoolId: NodepoolId)(
-          implicit ev: Ask[IO, TraceId]
-        ): IO[Option[Operation]] =
-          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(Some(Operation.newBuilder().build()))
       }
 
-      val deps = initKubernetesClusterCheckerDeps(gkeService = gkeService)
+      var count = 0
 
+      val publisher = new FakeGooglePublisher {
+        override def publishOne[MessageType](message: MessageType)(implicit evidence$2: Encoder[MessageType],
+                                                                   ev: Ask[IO, TraceId]): IO[Unit] =
+          if (dryRun)
+            IO.raiseError(fail("Shouldn't publish message in dryRun mode"))
+          else {
+            count = count + 1
+            super.publishOne(message)(evidence$2, ev)
+          }
+      }
+
+      val deps = initNodepoolCheckerDeps(gkeService = gkeService, publisher = publisher)
       val deletedOrErroredNodepoolChecker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
+
       res.unsafeRunSync() shouldBe Some(nodepool)
+      if (dryRun) count shouldBe 0
+      else count shouldBe 1
     }
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
@@ -1,16 +1,18 @@
 package com.broadinstitute.dsp.resourceValidator
 
 import cats.effect.IO
-import com.broadinstitute.dsp.{CheckRunnerDeps, KubernetesClusterCheckerDeps, RuntimeCheckerDeps}
+import com.broadinstitute.dsp.{CheckRunnerDeps, KubernetesClusterCheckerDeps, NodepoolCheckerDeps, RuntimeCheckerDeps}
 import org.broadinstitute.dsde.workbench.google2.{
   GKEService,
   GoogleComputeService,
   GoogleDataprocService,
+  GooglePublisher,
   GoogleStorageService
 }
 import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleComputeService,
   FakeGoogleDataprocService,
+  FakeGooglePublisher,
   FakeGoogleStorageInterpreter,
   MockGKEService
 }
@@ -33,5 +35,14 @@ object InitDependenciesHelper {
     KubernetesClusterCheckerDeps(
       CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter),
       gkeService
+    )
+
+  def initNodepoolCheckerDeps(gkeService: GKEService[IO] = MockGKEService,
+                              googleStorageService: GoogleStorageService[IO] = FakeGoogleStorageInterpreter,
+                              publisher: GooglePublisher[IO] = new FakeGooglePublisher) =
+    NodepoolCheckerDeps(
+      CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter),
+      gkeService,
+      publisher
     )
 }


### PR DESCRIPTION
Tested against my fiab 
message successfully published:
{"@timestamp":"2020-11-20T15:19:19.725Z","@version":"1","message":"{\"response\":\"()\",\"result\":\"Succeeded\",\"traceId\":\"50c24029-23d3-4bd3-b68e-2e87e3063f41\",\"googleCall\":\"com.google.cloud.pubsub.v1.Publisher.publish(<ByteString@5a56c8b7 size=138 contents=\\\"{\\\\\\\"messageType\\\\\\\":\\\\\\\"deleteNodepool\\\\\\\",\\\\\\\"nodepoolId\\\\\\\":22...\\\">)\",\"duration\":\"448 milliseconds\"}","logger_name":"com.broadinstitute.dsp.resourceValidator.ResourceValidator","thread_name":"Gax-11","severity":"INFO","level_value":20000,"traceId":"50c24029-23d3-4bd3-b68e-2e87e3063f41","googleCall":"com.google.cloud.pubsub.v1.Publisher.publish(<ByteString@5a56c8b7 size=138 contents=\"{\\\"messageType\\\":\\\"deleteNodepool\\\",\\\"nodepoolId\\\":22...\">)","duration":"448 milliseconds"}

Leo processes message:
[INFO] [15:19:20.807] [Gax-179] o.b.d.workbench.leonardo.http.Boot - Subscriber Successfully received data: "{\"messageType\":\"deleteNodepool\",\"nodepoolId\":222,\"googleProject\":\"callisto-dev\",\"traceId\":\"DeletedOrErroredNodepoolChecker-1605885559047\"}"