### PR TITLE
[IA-2352] add check if billing is enabled to checkers

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -9,6 +9,7 @@ import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.google2.{
   GKEService,
+  GoogleBillingService,
   GoogleComputeService,
   GoogleDataprocService,
   GoogleDiskService,
@@ -76,3 +77,5 @@ final case class NodepoolCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F],
 final case class DiskCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F], googleDiskService: GoogleDiskService[F])
 
 final case class RuntimeCheckerConfig(pathToCredential: Path, reportDestinationBucket: GcsBucketName)
+
+final case class BillingDeps[F[_]](runtimeCheckerDeps: RuntimeCheckerDeps[F], billingService: GoogleBillingService[F])

--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -40,8 +40,7 @@ object RuntimeCheckerDeps {
                                                               scopedCredential,
                                                               blocker,
                                                               regionName,
-                                                              blockerBound,
-                                                              RetryPredicates.standardRetryConfig)
+                                                              blockerBound)
     } yield {
       val checkRunnerDeps = CheckRunnerDeps(config.reportDestinationBucket, storageService, metrics)
       RuntimeCheckerDeps(computeService, dataprocService, checkRunnerDeps)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.18-b4202c9b-SNAP"
+  val workbenchGoogle2Version = "0.19-bc594f9"
   val doobieVersion = "0.9.4"
   val openTelemetryVersion = "0.1-e66171c"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.18-c9edd8e"
+  val workbenchGoogle2Version = "0.18-b4202c9b-SNAP"
   val doobieVersion = "0.9.4"
   val openTelemetryVersion = "0.1-e66171c"
 
@@ -23,9 +23,11 @@ object Dependencies {
     "com.google.cloud" % "google-cloud-dataproc" % "0.122.1",
     "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version % Test classifier "tests",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
-    "org.scalatestplus" %% "mockito-3-3" % "3.2.0.0" % Test // https://github.com/scalatest/scalatestplus-selenium
+    "org.scalatestplus" %% "mockito-3-3" % "3.2.0.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
+    "ca.mrvisser" %% "sealerate" % "0.0.6"
   )
 
   val resourceValidator = core

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -13,14 +13,14 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 object DeletedRuntimeChecker {
   def impl[F[_]: Timer](
     dbReader: DbReader[F],
-    deps: RuntimeCheckerDeps[F]
+    deps: BillingDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =
     new CheckRunner[F, Runtime] {
       override def appName: String = resourceValidator.appName
 
       override def configs = CheckRunnerConfigs(s"deleted-runtime", shouldAlert = true)
 
-      override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+      override def dependencies: CheckRunnerDeps[F] = deps.runtimeCheckerDeps.checkRunnerDeps
 
       override def resourceToScan: fs2.Stream[F, Runtime] = dbReader.getDeletedRuntimes
 
@@ -37,28 +37,41 @@ object DeletedRuntimeChecker {
         implicit ev: Ask[F, TraceId]
       ): F[Option[Runtime]] =
         for {
-          clusterOpt <- deps.dataprocService
+          clusterOpt <- deps.runtimeCheckerDeps.dataprocService
             .getCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
-          _ <- clusterOpt.traverse_ { _ =>
+          isBillingEnabled <- deps.billingService.isBillingEnabled(runtime.googleProject)
+          r <- clusterOpt.flatTraverse { _ =>
             if (isDryRun)
-              logger.warn(s"${runtime} still exists in Google. It needs to be deleted.")
+              logger
+                .warn(
+                  s"$runtime still exists in Google. It needs to be deleted. isBillingEnabled: $isBillingEnabled. Project: ${runtime.googleProject}"
+                )
+                .as(Option(runtime))
             else
-              logger.warn(s"${runtime} still exists in Google. Going to delete it.") >> deps.dataprocService
-                .deleteCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
-                .void
+              isBillingEnabled match {
+                case true =>
+                  logger.warn(s"$runtime still exists in Google and billing is enabled. Going to delete it.") >> deps.runtimeCheckerDeps.dataprocService
+                    .deleteCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
+                    .as(Option(runtime))
+                case false =>
+                  logger
+                    .warn(s"$runtime still exists with an anomaly, but cannot delete it because billing is disabled.")
+                    .as(none[Runtime])
+              }
+
           }
-        } yield clusterOpt.fold(none[Runtime])(_ => Some(runtime))
+        } yield r
 
       private def checkGceRuntime(runtime: Runtime, isDryRun: Boolean): F[Option[Runtime]] =
         for {
-          runtimeOpt <- deps.computeService
+          runtimeOpt <- deps.runtimeCheckerDeps.computeService
             .getInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
           _ <- runtimeOpt.traverse_ { _ =>
             if (isDryRun)
               logger.warn(s"${runtime} still exists in Google. It needs to be deleted")
             else
               logger.warn(s"${runtime} still exists in Google. Going to delete") >>
-                deps.computeService
+                deps.runtimeCheckerDeps.computeService
                   .deleteInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
                   .void
           }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -56,7 +56,9 @@ object DeletedRuntimeChecker {
                       .as(Option(runtime))
                   case false =>
                     logger
-                      .info(s"$runtime has been reported from getCluster, but billing is disabled so cannot perform any actions.")
+                      .info(
+                        s"$runtime has been reported from getCluster, but billing is disabled so cannot perform any actions."
+                      )
                       .as(none[Runtime])
                 }
             } yield r

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -56,7 +56,7 @@ object DeletedRuntimeChecker {
                       .as(Option(runtime))
                   case false =>
                     logger
-                      .warn(s"$runtime still exists with an anomaly, but cannot delete it because billing is disabled.")
+                      .info(s"$runtime has been reported from getCluster, but billing is disabled so cannot perform any actions.")
                       .as(none[Runtime])
                 }
             } yield r

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
@@ -13,12 +13,12 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 object ErroredRuntimeChecker {
   def iml[F[_]: Timer](
     dbReader: DbReader[F],
-    deps: RuntimeCheckerDeps[F]
+    deps: BillingDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =
     new CheckRunner[F, Runtime] {
       override def appName: String = resourceValidator.appName
       override def configs = CheckRunnerConfigs(s"errored-runtime", shouldAlert = true)
-      override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+      override def dependencies: CheckRunnerDeps[F] = deps.runtimeCheckerDeps.checkRunnerDeps
       override def resourceToScan: fs2.Stream[F, Runtime] = dbReader.getErroredRuntimes
 
       override def checkResource(runtime: Runtime, isDryRun: Boolean)(
@@ -32,8 +32,9 @@ object ErroredRuntimeChecker {
 
       def checkDataprocCluster(runtime: Runtime, isDryRun: Boolean)(implicit ev: Ask[F, TraceId]): F[Option[Runtime]] =
         for {
-          clusterOpt <- deps.dataprocService
+          clusterOpt <- deps.runtimeCheckerDeps.dataprocService
             .getCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
+          isBillingEnabled <- deps.billingService.isBillingEnabled(runtime.googleProject)
           r <- clusterOpt.flatTraverse[F, Runtime] { cluster =>
             if (cluster.getStatus.getState.name.toUpperCase == "ERROR")
               logger
@@ -43,30 +44,40 @@ object ErroredRuntimeChecker {
               if (isDryRun)
                 logger
                   .warn(
-                    s"${runtime} still exists in ${cluster.getStatus.getState.name} status. It needs to be deleted."
+                    s"${runtime} still exists in ${cluster.getStatus.getState.name} status. It needs to be deleted. isBillingEnabled: $isBillingEnabled. Project: ${runtime.googleProject}"
                   )
                   .as(Some(runtime))
               else
-                logger.warn(
-                  s"${runtime} still exists in ${cluster.getStatus.getState.name} status. Going to delete it."
-                ) >> deps.dataprocService
-                  .deleteCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
-                  .void
-                  .as(Some(runtime))
+                isBillingEnabled match {
+                  case true =>
+                    logger.warn(
+                      s"${runtime} still exists in ${cluster.getStatus.getState.name} status with billing enabled. Going to delete it."
+                    ) >> deps.runtimeCheckerDeps.dataprocService
+                      .deleteCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
+                      .void
+                      .as(Some(runtime))
+                  case false =>
+                    logger
+                      .warn(
+                        s"${runtime} still exists with an anomaly, but cannot delete it because billing is disabled."
+                      )
+                      .as(none[Runtime])
+                }
+
             }
           }
         } yield r
 
       def checkGceRuntime(runtime: Runtime, isDryRun: Boolean): F[Option[Runtime]] =
         for {
-          runtimeOpt <- deps.computeService
+          runtimeOpt <- deps.runtimeCheckerDeps.computeService
             .getInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
           _ <- runtimeOpt.traverse_ { rt =>
             if (isDryRun)
               logger.warn(s"${runtime} still exists in ${rt.getStatus} status. It needs to be deleted.")
             else
               logger.warn(s"${runtime} still exists in ${rt.getStatus} status. Going to delete it.") >>
-                deps.computeService
+                deps.runtimeCheckerDeps.computeService
                   .deleteInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
                   .void
           }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
@@ -59,8 +59,8 @@ object ErroredRuntimeChecker {
                         .as(Option(runtime))
                     case false =>
                       logger
-                        .warn(
-                          s"${runtime} still exists with an anomaly, but cannot delete it because billing is disabled."
+                        .info(
+                          s"$runtime has been reported from getCluster, but billing is disabled so cannot perform any actions"
                         )
                         .as(none[Runtime])
                   }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
@@ -4,6 +4,7 @@ package resourceValidator
 import cats.effect.IO
 import cats.implicits._
 import com.monovore.decline.{CommandApp, _}
+
 import scala.concurrent.ExecutionContext.global
 
 object Main

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -6,14 +6,20 @@ import cats.mtl.Ask
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initRuntimeCheckerDeps
 import com.google.cloud.compute.v1.{Instance, Operation}
-import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
+import com.google.cloud.dataproc.v1.Cluster
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.mock.{
   BaseFakeGoogleDataprocService,
   FakeGoogleBillingInterpreter,
   FakeGoogleComputeService
 }
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  DataprocClusterName,
+  DataprocOperation,
+  InstanceName,
+  RegionName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
@@ -72,7 +78,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[ClusterOperationMetadata]] =
+        ): IO[Option[DataprocOperation]] =
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
@@ -102,7 +108,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[ClusterOperationMetadata]] =
+        ): IO[Option[DataprocOperation]] =
           IO.pure(None)
       }
 

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -8,7 +8,11 @@ import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initRunti
 import com.google.cloud.compute.v1.{Instance, Operation}
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  BaseFakeGoogleDataprocService,
+  FakeGoogleBillingInterpreter,
+  FakeGoogleComputeService
+}
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -29,12 +33,13 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
     val runtimeCheckerDeps =
       initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
+    val billingDeps = BillingDeps(runtimeCheckerDeps, FakeGoogleBillingInterpreter)
 
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getDeletedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
       }
-      val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, runtimeCheckerDeps)
+      val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, billingDeps)
       val res = deletedRuntimeChecker.checkResource(runtime, dryRun)
       res.unsafeRunSync() shouldBe None
     }
@@ -73,10 +78,45 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
       val runtimeCheckerDeps =
         initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
+      val billingDeps = BillingDeps(runtimeCheckerDeps, FakeGoogleBillingInterpreter)
 
-      val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, runtimeCheckerDeps)
+      val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, billingDeps)
       val res = deletedRuntimeChecker.checkResource(runtime, dryRun)
       res.unsafeRunSync() shouldBe Some(runtime)
+    }
+  }
+
+  it should "return None if a dataproc cluster exists in google but has billing disabled and it is not a dry run" in {
+    forAll { (runtime: Runtime) =>
+      val dbReader = new FakeDbReader {
+        override def getDeletedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
+      }
+
+      val dataprocService = new BaseFakeGoogleDataprocService {
+        override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
+          implicit ev: Ask[IO, TraceId]
+        ): IO[Option[Cluster]] = {
+          val cluster = Cluster.newBuilder().build()
+          IO.pure(Some(cluster))
+        }
+
+        override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
+          implicit ev: Ask[IO, TraceId]
+        ): IO[Option[ClusterOperationMetadata]] =
+          IO.pure(None)
+      }
+
+      val runtimeCheckerDeps =
+        initRuntimeCheckerDeps(googleDataprocService = dataprocService)
+      val billingService = new FakeGoogleBillingInterpreter {
+        override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
+          IO.pure(false)
+      }
+      val billingDeps = BillingDeps(runtimeCheckerDeps, billingService)
+
+      val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, billingDeps)
+      val res = deletedRuntimeChecker.checkResource(runtime, false)
+      res.unsafeRunSync() shouldBe None
     }
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -7,14 +7,20 @@ import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper._
 import com.google.cloud.compute.v1.{Instance, Operation}
 import com.google.cloud.dataproc.v1.ClusterStatus.State
-import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata, ClusterStatus}
+import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.mock.{
   BaseFakeGoogleDataprocService,
   FakeGoogleBillingInterpreter,
   FakeGoogleComputeService
 }
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  DataprocClusterName,
+  DataprocOperation,
+  InstanceName,
+  RegionName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
@@ -73,7 +79,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[ClusterOperationMetadata]] =
+        ): IO[Option[DataprocOperation]] =
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
@@ -102,7 +108,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[ClusterOperationMetadata]] =
+        ): IO[Option[DataprocOperation]] =
           IO.raiseError(fail("this shouldn't be called"))
       }
 


### PR DESCRIPTION
In non-dry runs, the deleted and errored runtime checkers first check if billing is enabled before attempted to delete the runtime. 

This relies on the merged wb-libs PR is here: https://github.com/broadinstitute/workbench-libs/pull/474/files