### PR TITLE
IA-2415 update query to only care about recently deleted runtimes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 
 object Dependencies {
   val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.19-bc594f9"
-  val doobieVersion = "0.9.4"
-  val openTelemetryVersion = "0.1-e66171c"
+  val workbenchGoogle2Version = "0.19-f0578d6"
+  val doobieVersion = "0.10.0"
+  val openTelemetryVersion = "0.1-f0578d6"
 
   val core = Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "6.2",
@@ -15,18 +15,15 @@ object Dependencies {
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.13.0",
     "mysql" % "mysql-connector-java" % "8.0.18",
-    "org.scalatest" %% "scalatest" % "3.2.0" % Test,
+    "org.scalatest" %% "scalatest" % "3.2.3" % Test,
     "com.monovore" %% "decline" % "1.0.0",
-    "co.fs2" %% "fs2-io" % "2.4.2",
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion,
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion % Test classifier "tests",
-    "com.google.cloud" % "google-cloud-dataproc" % "0.122.1",
-    "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version % Test classifier "tests",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
-    "org.scalatestplus" %% "mockito-3-3" % "3.2.0.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
+    "org.scalatestplus" %% "mockito-3-4" % "3.2.3.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
     "ca.mrvisser" %% "sealerate" % "0.0.6"
   )
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -27,13 +27,16 @@ object DbReader {
 
   val deletedDisksQuery =
     sql"""
-           select pd1.id, pd1.googleProject, pd1.name from PERSISTENT_DISK as pd1 where pd1.status="Deleted" and
-           NOT EXISTS
-           (
-             SELECT *
-             FROM PERSISTENT_DISK pd2
-             WHERE pd1.googleProject = pd2.googleProject and pd1.name = pd2.name and pd2.status != "Deleted"
-          )
+           select pd1.id, pd1.googleProject, pd1.name 
+           FROM PERSISTENT_DISK as pd1 
+           WHERE pd1.status="Deleted" and
+             pd1.destroyedDate > now() - INTERVAL 90 DAY AND
+             NOT EXISTS
+             (
+               SELECT *
+               FROM PERSISTENT_DISK pd2
+               WHERE pd1.googleProject = pd2.googleProject and pd1.name = pd2.name and pd2.status != "Deleted"
+              )
         """.query[Disk]
 
   val initBucketsToDeleteQuery =
@@ -44,14 +47,16 @@ object DbReader {
     sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
-          WHERE c1.status = "Deleted" AND
-          NOT EXISTS (
-            SELECT *
-            FROM CLUSTER AS c2
-            WHERE
-              c2.googleProject = c1.googleProject AND
-              c2.clusterName = c1.clusterName AND
-              (c2.status = "Stopped" OR c2.status = "Running")
+          WHERE 
+            c1.status = "Deleted" AND
+            c1.destroyedDate > now() - INTERVAL 90 DAY AND
+            NOT EXISTS (
+              SELECT *
+              FROM CLUSTER AS c2
+              WHERE
+                c2.googleProject = c1.googleProject AND
+                c2.clusterName = c1.clusterName AND
+                (c2.status = "Stopped" OR c2.status = "Running")
           )"""
       .query[Runtime]
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -28,8 +28,8 @@ object DbReader {
   val deletedDisksQuery =
     sql"""
            select pd1.id, pd1.googleProject, pd1.name 
-           FROM PERSISTENT_DISK as pd1 
-           WHERE pd1.status="Deleted" and
+           FROM PERSISTENT_DISK AS pd1 
+           WHERE pd1.status="Deleted" AND
              pd1.destroyedDate > now() - INTERVAL 90 DAY AND
              NOT EXISTS
              (


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2415

only scan runtimes, disks that are deleted in the last 90 days. Assuming that runtimes/disks deleted earlier then 90 days have already been checked many times