### PR TITLE
[no ticket] Attempt to make db connection error less often

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 
 object Dependencies {
   val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.19-f0578d6"
+  val workbenchGoogle2Version = "0.19-1aba7fd"
   val doobieVersion = "0.10.0"
-  val openTelemetryVersion = "0.1-f0578d6"
+  val openTelemetryVersion = "0.1-1aba7fd"
 
   val core = Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "6.2",
@@ -13,7 +13,7 @@ object Dependencies {
     "org.tpolecat" %% "doobie-core" % doobieVersion,
     "org.tpolecat" %% "doobie-hikari" % doobieVersion,
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
-    "com.github.pureconfig" %% "pureconfig" % "0.13.0",
+    "com.github.pureconfig" %% "pureconfig" % "0.14.0",
     "mysql" % "mysql-connector-java" % "8.0.18",
     "org.scalatest" %% "scalatest" % "3.2.3" % Test,
     "com.monovore" %% "decline" % "1.0.0",

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -32,7 +32,7 @@ object DbReader {
            select pd1.id, pd1.googleProject, pd1.name
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
-             pd1.destroyedDate > now() - INTERVAL 90 DAY AND
+             pd1.destroyedDate > now() - INTERVAL 30 DAY AND
              NOT EXISTS
              (
                SELECT *
@@ -51,7 +51,7 @@ object DbReader {
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
             c1.status = "Deleted" AND
-            c1.destroyedDate > now() - INTERVAL 90 DAY AND
+            c1.destroyedDate > now() - INTERVAL 30 DAY AND
             NOT EXISTS (
               SELECT *
               FROM CLUSTER AS c2

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
@@ -97,7 +97,7 @@ object ResourceValidator {
         workerProcess
       ).covary[F]
 
-      _ <- processes.parJoinUnbounded
+      _ <- processes.parJoin(9)
     } yield ExitCode.Success
   }.drain
 

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -52,7 +52,7 @@ object ZombieMonitor {
                          deleteRuntimeCheckerProcess,
                          deletek8sClusterCheckerProcess,
                          deleteOrErroredNodepoolCheckerProcess).covary[F]
-      _ <- processes.parJoin(2)
+      _ <- processes.parJoin(4)
     } yield ExitCode.Success
   }.drain
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2490

```
Exception in thread "main" java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30000ms.
        at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:695)
        at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:197)
```

This error seems to happen more frequently recently in resource-validator. I asked in doobie gitter channel, the suggestion is read all records into memory instead because `.stream.transact(xa)` only closes connection once the `Stream` terminates.

I'm thinking we can reduce the number of records even further by reducing number of days we look back. Since resource-validator runs every day, so technically, this should totally be fine.

Another change I made is reduce parallelism for `resource-validator` in hope of reducing the connection not available error