### PR TITLE
IA-2589 support multi zone and region

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run tests
-        run: sbt coverage test coverageReport
+        run: sbt coverage "testOnly -- -l cronJobs.dbTest" coverageReport
       - name: Check output
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ sbt <project>/run --help
 
 e.g. `sbt "resourceValidator/run --dryRun --all"`
 
+Run unit tests (excluding unit tests require database access):
+`testOnly -- -l cronJobs.dbTest`
+
+Run all unit tests require database access:
+`testOnly -- -n cronJobs.dbTest`
+
 ## Contributing
 
 1. Run these unit tests locally before making a PR:

--- a/build.sbt
+++ b/build.sbt
@@ -25,3 +25,5 @@ lazy val cleanup = (project in file("nuker"))
   .settings(Settings.nukerSettings)
   .enablePlugins(JavaAppPackaging)
   .dependsOn(core % "test->test;compile->compile")
+
+parallelExecution in Test := false

--- a/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
@@ -5,10 +5,10 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GooglePublisher, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName

--- a/core/src/main/scala/com/broadinstitute/dsp/ConfigImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/ConfigImplicits.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 
 import java.nio.file.{Path, Paths}
 
-import cats.implicits._
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import pureconfig.ConfigReader
 import pureconfig.error.{ExceptionThrown, FailureReason}

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -1,11 +1,12 @@
 package com.broadinstitute.dsp
 
-import cats.implicits._
-import doobie.{Get, Meta}
+import cats.syntax.all._
+import doobie.{Get, Meta, Read}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import doobie.implicits.javasql.TimestampMeta
+
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -27,4 +28,32 @@ object DbReaderImplicits {
   implicit val k8sClusterNameMeta: Meta[KubernetesClusterName] = Meta[String].imap(KubernetesClusterName)(_.value)
   implicit val locationMeta: Meta[Location] = Meta[String].imap(Location)(_.value)
   implicit val regionNameMeta: Meta[RegionName] = Meta[String].imap(RegionName(_))(_.value)
+  implicit val runtimeRead: Read[Runtime] =
+    Read[(Long, GoogleProject, String, CloudService, String, Option[ZoneName], Option[RegionName])].map {
+      case (id, project, runtimeName, cloudService, status, zone, region) =>
+        (zone, region) match {
+          case (Some(_), Some(_)) =>
+            throw new RuntimeException(
+              s"${cloudService} Runtime ${id} has both zone and region defined. This is impossible. Fix this in DB"
+            )
+          case (Some(z), None) =>
+            if (cloudService == CloudService.Gce)
+              Runtime.Gce(id, project, runtimeName, cloudService, status, z)
+            else
+              throw new RuntimeException(
+                s"Dataproc runtime ${id} has no region defined. This is impossible. Fix this in DB"
+              )
+          case (None, Some(r)) =>
+            if (cloudService == CloudService.Dataproc)
+              Runtime.Dataproc(id, project, runtimeName, cloudService, status, r)
+            else
+              throw new RuntimeException(
+                s"Gce runtime ${id} has no zone defined. This is impossible. Fix this in DB"
+              )
+          case (None, None) =>
+            throw new RuntimeException(
+              s"${cloudService} Runtime ${id} has no zone and no region defined. This is impossible. Fix this in DB"
+            )
+        }
+    }
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/package.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/package.scala
@@ -1,16 +1,43 @@
 package com.broadinstitute
 
-import java.nio.file.Path
-
 import cats.effect.{Resource, Sync, Timer}
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import org.broadinstitute.dsde.workbench.google2.{RegionName, ZoneName}
 
+import java.nio.file.Path
 import scala.jdk.CollectionConverters._
 
 package object dsp {
-  val zoneName = ZoneName("us-central1-a")
-  val regionName = RegionName("us-central1")
+  // TODO: remove all references to this after https://broadworkbench.atlassian.net/browse/IA-2640
+  val defaultZoneNameForDiskOnly = ZoneName("us-central1-a")
+
+  val supportedRegions = Set(
+    "northamerica-northeast1",
+    "southamerica-east1",
+    "us-central1",
+    "us-east1",
+    "us-east4",
+    "us-west1",
+    "us-west2",
+    "us-west3",
+    "us-west4",
+    "europe-central2",
+    "europe-north1",
+    "europe-west1",
+    "europe-west2",
+    "europe-west3",
+    "europe-west4",
+    "europe-west6",
+    "asia-east1",
+    "asia-east2",
+    "asia-northeast1",
+    "asia-northeast2",
+    "asia-northeast3",
+    "asia-south1",
+    "asia-southeast1",
+    "asia-southeast2",
+    "australia-southeast1"
+  ).map(s => RegionName(s))
 
   def initGoogleCredentials[F[_]: Sync: Timer](
     pathToCredential: Path

--- a/core/src/test/scala/com/broadinstitute/dsp/CronJobsTestSuite.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/CronJobsTestSuite.scala
@@ -2,8 +2,8 @@ package com.broadinstitute.dsp
 
 import cats.effect.{Blocker, ContextShift, IO, Timer}
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.StructuredLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration

--- a/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
@@ -2,7 +2,6 @@ package com.broadinstitute.dsp
 
 import java.time.Instant
 import java.util.UUID
-
 import cats.effect.{ContextShift, IO, Resource}
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
@@ -11,9 +10,13 @@ import doobie.Put
 import doobie.util.transactor.Transactor
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
+import org.broadinstitute.dsde.workbench.google2.{RegionName, ZoneName}
+import org.scalatest.Tag
 
 object DBTestHelper {
   implicit val cloudServicePut: Put[CloudService] = Put[String].contramap(cloudService => cloudService.asString)
+  val zoneName = ZoneName("us-central1-a")
+  val regionName = RegionName("us-central1")
 
   def yoloTransactor(implicit cs: ContextShift[IO], databaseConfig: DatabaseConfig): Transactor[IO] =
     Transactor.fromDriverManager[IO](
@@ -99,14 +102,18 @@ object DBTestHelper {
          ${UUID.randomUUID().toString})
          """.update.withUniqueGeneratedKeys[Long]("id").transact(xa)
 
-  def insertRuntimeConfig(cloudService: CloudService)(implicit xa: HikariTransactor[IO]): IO[Long] =
+  def insertRuntimeConfig(cloudService: CloudService)(implicit xa: HikariTransactor[IO]): IO[Long] = {
+    val zone = if (cloudService == CloudService.Gce) Some(zoneName.value) else None
+    val region = if (cloudService == CloudService.Dataproc) Some(regionName.value) else None
     sql"""INSERT INTO RUNTIME_CONFIG
          (cloudService,
           machineType,
           diskSize,
           numberOfWorkers,
           dateAccessed,
-          bootDiskSize
+          bootDiskSize,
+          zone,
+          region
          )
          VALUES (
          ${cloudService},
@@ -114,9 +121,12 @@ object DBTestHelper {
          100,
          0,
          now(),
-         30
+         30,
+         ${zone},
+         ${region}
          )
          """.update.withUniqueGeneratedKeys[Long]("id").transact(xa)
+  }
 
   def insertNamespace(clusterId: Long, namespaceName: NamespaceName)(
     implicit xa: HikariTransactor[IO]
@@ -207,3 +217,5 @@ object DBTestHelper {
 }
 
 final case class RuntimeError(errorCode: Option[Int], errorMessage: String)
+
+object DbTest extends Tag("cronJobs.dbTest")

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Config.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Config.scala
@@ -3,7 +3,7 @@ package nuker
 
 import java.nio.file.Path
 
-import cats.implicits._
+import cats.syntax.all._
 import pureconfig._
 import pureconfig.generic.auto._
 import com.broadinstitute.dsp.ConfigImplicits._

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 package nuker
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import com.monovore.decline.{CommandApp, _}
 import scala.concurrent.ExecutionContext.global
 

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
@@ -7,8 +7,8 @@ import cats.Parallel
 import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, ExitCode, Resource, Sync, Timer}
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.StructuredLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.google2.{GoogleSubscriptionAdmin, GoogleTopicAdmin}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
@@ -7,7 +7,7 @@ import cats.effect.{Concurrent, Timer}
 import cats.mtl.Ask
 import com.google.pubsub.v1.{ProjectSubscriptionName, TopicName}
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{GoogleSubscriptionAdmin, GoogleTopicAdmin}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.19-1aba7fd"
-  val doobieVersion = "0.10.0"
+  val workbenchGoogle2Version = "0.20-cba9b6c"
+  val doobieVersion = "0.12.1"
   val openTelemetryVersion = "0.1-1aba7fd"
 
   val core = Seq(
@@ -13,10 +13,12 @@ object Dependencies {
     "org.tpolecat" %% "doobie-core" % doobieVersion,
     "org.tpolecat" %% "doobie-hikari" % doobieVersion,
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
-    "com.github.pureconfig" %% "pureconfig" % "0.14.0",
+    "com.github.pureconfig" %% "pureconfig" % "0.14.1",
     "mysql" % "mysql-connector-java" % "8.0.18",
     "org.scalatest" %% "scalatest" % "3.2.3" % Test,
     "com.monovore" %% "decline" % "1.0.0",
+    "com.github.julien-truffaut" %% "monocle-core" % "3.0.0-M4",
+    "com.github.julien-truffaut" %% "monocle-macro" % "3.0.0-M4",
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion,
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion % Test classifier "tests",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -59,7 +59,8 @@ object Settings {
     "-language:postfixOps",
     "-feature",
     "-Xfatal-warnings",
-    "-Ywarn-unused:imports"
+    "-Ywarn-unused:imports",
+    "-Ymacro-annotations"
   )
 
   private lazy val commonSettings = List(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.4
+sbt.version=1.5.0
 

--- a/resource-validator/cloudbuild.yaml
+++ b/resource-validator/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: 'gcr.io/$PROJECT_ID/scala-sbt'
     args:
       - |
-        test; resourceValidator/docker:publishLocal
+        testOnly -- -l cronJobs.dbTest; resourceValidator/docker:publishLocal
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/resource-validator:latest', 'us.gcr.io/broad-dsp-gcr-public/resource-validator:$SHORT_SHA']
 images: [

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/BucketRemover.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/BucketRemover.scala
@@ -2,9 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Config.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Config.scala
@@ -3,7 +3,7 @@ package resourceValidator
 
 import java.nio.file.Path
 
-import cats.implicits._
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import pureconfig._
 import pureconfig.generic.auto._

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerChecker.scala
@@ -2,9 +2,8 @@ package com.broadinstitute.dsp.resourceValidator
 
 import cats.effect.{Concurrent, Timer}
 import cats.mtl.Ask
-import cats.implicits._
+import cats.syntax.all._
 import com.broadinstitute.dsp.{
-  regionName,
   resourceValidator,
   CheckRunner,
   CheckRunnerConfigs,
@@ -12,7 +11,7 @@ import com.broadinstitute.dsp.{
   RuntimeCheckerDeps,
   RuntimeWithWorkers
 }
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.DataprocClusterName
 import org.broadinstitute.dsde.workbench.model.TraceId
 
@@ -37,7 +36,7 @@ object DataprocWorkerChecker {
       ): F[Option[RuntimeWithWorkers]] =
         for {
           clusterOpt <- deps.dataprocService
-            .getCluster(runtime.r.googleProject, regionName, DataprocClusterName(runtime.r.runtimeName))
+            .getCluster(runtime.r.googleProject, runtime.r.region, DataprocClusterName(runtime.r.runtimeName))
           runtime <- clusterOpt.flatTraverse { c =>
             val doesPrimaryWorkerMatch =
               runtime.workerConfig.numberOfWorkers.getOrElse(0) == c.getConfig.getWorkerConfig.getNumInstances
@@ -65,7 +64,7 @@ object DataprocWorkerChecker {
                       deps.dataprocService
                         .resizeCluster(
                           runtime.r.googleProject,
-                          regionName,
+                          runtime.r.region,
                           DataprocClusterName(runtime.r.runtimeName),
                           if (doesPrimaryWorkerMatch) None else Some(runtime.workerConfig.numberOfWorkers.getOrElse(0)),
                           if (doesSecondaryWorkerMatch) None

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -46,7 +46,7 @@ object DbReader {
       .query[InitBucketToRemove]
 
   val deletedRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status
+    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
@@ -63,7 +63,7 @@ object DbReader {
       .query[Runtime]
 
   val erroredRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status
+    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
@@ -79,7 +79,7 @@ object DbReader {
       .query[Runtime]
 
   val stoppedRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, c1.googleProject, c1.clusterName, rt.cloudService, c1.status
+    sql"""SELECT DISTINCT c1.id, c1.googleProject, c1.clusterName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
@@ -174,7 +174,7 @@ object DbReader {
       .query[KubernetesClusterToRemove]
 
   val dataprocClusterWithWorkersQuery =
-    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.numberOfWorkers, rt.numberOfPreemptibleWorkers
+    sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.region, rt.numberOfWorkers, rt.numberOfPreemptibleWorkers
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
           WHERE rt.cloudService="DATAPROC" AND NOT c1.status="DELETED"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -2,9 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 // Implements CheckRunner[F[_], A]
@@ -23,9 +23,11 @@ object DeletedDiskChecker {
         implicit ev: Ask[F, TraceId]
       ): F[Option[Disk]] =
         for {
-          diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, zoneName, disk.diskName)
+          diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, defaultZoneNameForDiskOnly, disk.diskName)
           _ <- if (!isDryRun) {
-            diskOpt.traverse(_ => deps.googleDiskService.deleteDisk(disk.googleProject, zoneName, disk.diskName))
+            diskOpt.traverse(_ =>
+              deps.googleDiskService.deleteDisk(disk.googleProject, defaultZoneNameForDiskOnly, disk.diskName)
+            )
           } else F.pure(None)
         } yield diskOpt.map(_ => disk)
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
@@ -2,9 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.model.TraceId
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
@@ -4,9 +4,9 @@ package resourceValidator
 import java.util.concurrent.TimeUnit
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolId}
 import org.broadinstitute.dsde.workbench.model.TraceId
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -2,10 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import com.broadinstitute.dsp.CloudService.{Dataproc, Gce}
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 
@@ -26,19 +25,19 @@ object DeletedRuntimeChecker {
 
       override def checkResource(runtime: Runtime,
                                  isDryRun: Boolean)(implicit ev: Ask[F, TraceId]): F[Option[Runtime]] =
-        runtime.cloudService match {
-          case Dataproc =>
-            checkDataprocCluster(runtime, isDryRun)
-          case Gce =>
-            checkGceRuntime(runtime, isDryRun)
+        runtime match {
+          case x: Runtime.Dataproc =>
+            checkDataprocCluster(x, isDryRun)
+          case x: Runtime.Gce =>
+            checkGceRuntime(x, isDryRun)
         }
 
-      private def checkDataprocCluster(runtime: Runtime, isDryRun: Boolean)(
+      private def checkDataprocCluster(runtime: Runtime.Dataproc, isDryRun: Boolean)(
         implicit ev: Ask[F, TraceId]
       ): F[Option[Runtime]] =
         for {
           clusterOpt <- deps.dataprocService
-            .getCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
+            .getCluster(runtime.googleProject, runtime.region, DataprocClusterName(runtime.runtimeName))
           r <- clusterOpt.flatTraverse { _ =>
             for {
               isBillingEnabled <- deps.billingService.isBillingEnabled(runtime.googleProject)
@@ -47,35 +46,35 @@ object DeletedRuntimeChecker {
                   .warn(
                     s"$runtime still exists in Google. It needs to be deleted. isBillingEnabled: $isBillingEnabled. Project: ${runtime.googleProject}"
                   )
-                  .as(Option(runtime))
+                  .as(runtime.some)
               else
                 isBillingEnabled match {
                   case true =>
                     logger.warn(s"$runtime still exists in Google and billing is enabled. Going to delete it.") >> deps.dataprocService
-                      .deleteCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
-                      .as(Option(runtime))
+                      .deleteCluster(runtime.googleProject, runtime.region, DataprocClusterName(runtime.runtimeName))
+                      .as(runtime.some)
                   case false =>
                     logger
                       .info(
                         s"$runtime has been reported from getCluster, but billing is disabled so cannot perform any actions."
                       )
-                      .as(none[Runtime])
+                      .as(none[Runtime.Dataproc])
                 }
             } yield r
           }
         } yield r
 
-      private def checkGceRuntime(runtime: Runtime, isDryRun: Boolean): F[Option[Runtime]] =
+      private def checkGceRuntime(runtime: Runtime.Gce, isDryRun: Boolean): F[Option[Runtime]] =
         for {
           runtimeOpt <- deps.computeService
-            .getInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
+            .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
           _ <- runtimeOpt.traverse_ { _ =>
             if (isDryRun)
               logger.warn(s"${runtime} still exists in Google. It needs to be deleted")
             else
               logger.warn(s"${runtime} still exists in Google. Going to delete") >>
                 deps.computeService
-                  .deleteInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
+                  .deleteInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
                   .void
           }
         } yield runtimeOpt.fold(none[Runtime])(_ => Some(runtime))

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/InitBucketChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/InitBucketChecker.scala
@@ -2,9 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 object InitBucketChecker {

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/KubernetesClusterRemover.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/KubernetesClusterRemover.scala
@@ -4,10 +4,10 @@ package resourceValidator
 import java.util.concurrent.TimeUnit
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import io.circe.Encoder
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import com.monovore.decline.{CommandApp, _}
 
 import scala.concurrent.ExecutionContext.global

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/NodepoolRemover.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/NodepoolRemover.scala
@@ -2,9 +2,9 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import JsonCodec._
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
@@ -7,8 +7,8 @@ import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, ExitCod
 import cats.mtl.Ask
 import com.google.pubsub.v1.ProjectTopicName
 import fs2.Stream
-import io.chrisdavenport.log4cats.StructuredLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.google2.{GKEService, GoogleDiskService, GooglePublisher, PublisherConfig}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -1,20 +1,20 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.Parallel
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
 import cats.mtl.Ask
-import com.broadinstitute.dsp.CloudService.{Dataproc, Gce}
+import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object StoppedRuntimeChecker {
-  def iml[F[_]: Timer](
+  def iml[F[_]: Timer: Parallel](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =
@@ -26,36 +26,36 @@ object StoppedRuntimeChecker {
 
       override def checkResource(runtime: Runtime,
                                  isDryRun: Boolean)(implicit ev: Ask[F, TraceId]): F[Option[Runtime]] =
-        runtime.cloudService match {
-          case Dataproc =>
-            checkDataprocCluster(runtime, isDryRun)
-          case Gce =>
-            checkGceRuntime(runtime, isDryRun)
+        runtime match {
+          case x: Runtime.Dataproc =>
+            checkDataprocCluster(x, isDryRun)
+          case x: Runtime.Gce =>
+            checkGceRuntime(x, isDryRun)
         }
 
-      private def checkGceRuntime(runtime: Runtime, isDryRun: Boolean)(
+      private def checkGceRuntime(runtime: Runtime.Gce, isDryRun: Boolean)(
         implicit ev: Ask[F, TraceId]
       ): F[Option[Runtime]] =
         for {
           runtimeOpt <- deps.computeService
-            .getInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
+            .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
           runningRuntimeOpt <- runtimeOpt.flatTraverse { rt =>
             if (rt.getStatus == "RUNNING")
               if (isDryRun)
-                logger.warn(s"${runtime} is running. It needs to be stopped.").as(Option(runtime))
+                logger.warn(s"${runtime} is running. It needs to be stopped.").as[Option[Runtime]](Some(runtime))
               else
                 logger.warn(s"${runtime} is running. Going to stop it.") >>
                   // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
                   // in order to keep things simple since our main goal here is to prevent unintended cost to users.
                   deps.computeService
-                    .stopInstance(runtime.googleProject, zoneName, InstanceName(runtime.runtimeName))
+                    .stopInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
                     .void
-                    .as(Option(runtime))
+                    .as[Option[Runtime]](Some(runtime))
             else F.pure(none[Runtime])
           }
         } yield runningRuntimeOpt
 
-      private def checkDataprocCluster(runtime: Runtime, isDryRun: Boolean)(
+      private def checkDataprocCluster(runtime: Runtime.Dataproc, isDryRun: Boolean)(
         implicit ev: Ask[F, TraceId]
       ): F[Option[Runtime]] = {
         val clusterName = DataprocClusterName(runtime.runtimeName)
@@ -63,46 +63,51 @@ object StoppedRuntimeChecker {
 
         for {
           clusterOpt <- deps.dataprocService
-            .getCluster(runtime.googleProject, regionName, DataprocClusterName(runtime.runtimeName))
+            .getCluster(runtime.googleProject, runtime.region, DataprocClusterName(runtime.runtimeName))
           runningClusterOpt <- clusterOpt.flatTraverse { cluster =>
             if (cluster.getStatus.getState.name.toUpperCase == "RUNNING") {
               for {
                 // When we stop Dataproc clusters, we actually stop the underlying instances since it is not
                 // possible to stop Dataproc clusters otherwise. Therefore here, we are also checking that there is
                 // at least one underlying instance that is RUNNING.
-                runningInstanceExists <- containsRunningInstance(project, zoneName, regionName, clusterName)
+                runningInstanceExists <- containsRunningInstance(project, runtime.region, clusterName)
                 rt <- if (runningInstanceExists) {
                   if (isDryRun)
                     logger
                       .warn(s"Cluster (${runtime}) has running instance(s). It needs to be stopped.")
-                      .as(Option(runtime))
+                      .as(runtime.some)
                   else
                     logger.warn(s"Cluster (${runtime}) has running instances(s). Going to stop it.") >> deps.dataprocService
                     // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
                     // in order to keep things simple since our main goal here is to prevent unintended cost to users.
-                      .stopCluster(project, regionName, clusterName, metadata = None)
+                      .stopCluster(project, runtime.region, clusterName, metadata = None)
                       .void
-                      .as(Option(runtime))
-                } else F.pure(none[Runtime])
+                      .as(runtime.some)
+                } else F.pure(none[Runtime.Dataproc])
               } yield rt
-            } else F.pure(none[Runtime])
+            } else F.pure(none[Runtime.Dataproc])
           }
-        } yield runningClusterOpt
+        } yield runningClusterOpt: Option[Runtime]
       }
 
       private def containsRunningInstance(project: GoogleProject,
-                                          zone: ZoneName,
                                           region: RegionName,
                                           cluster: DataprocClusterName): F[Boolean] =
         for {
           instances <- deps.dataprocService.getClusterInstances(project, region, cluster)
+
           doesThereExistARunningInstance <- Stream
-            .emits(instances.values.toSeq.flatten)
+            .emits(instances.toList)
             .covary[F]
-            .parEvalMapUnordered(10) { instance =>
-              deps.computeService
-                .getInstance(project, zone, instance)
-                .handleErrorWith(_ => F.pure(none[Instance]))
+            .parEvalMapUnordered(5) {
+              case (dataprocZonePreemptible, instances) =>
+                instances.toList
+                  .parTraverse { instance =>
+                    deps.computeService
+                      .getInstance(project, dataprocZonePreemptible.zone, instance)
+                      .handleErrorWith(_ => F.pure(none[Instance]))
+                  }
+                  .map(_.flatten)
             }
             .exists(_.exists(_.getStatus == "RUNNING"))
             .compile

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DBReaderGetNodepoolsToDeleteSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DBReaderGetNodepoolsToDeleteSpec.scala
@@ -18,7 +18,6 @@ import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
 import RemovableNodepoolStatus.removableStatuses
-import org.scalatest.DoNotDiscover
 
 /**
  * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
@@ -28,7 +27,6 @@ import org.scalatest.DoNotDiscover
  *   * Run a database unit test in leonardo
  *   * Run this spec
  */
-@DoNotDiscover
 class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
@@ -42,7 +40,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   val destroyedDateBeyondGracePeriod = now.minusSeconds(gracePeriod + 200)
   val destroyedDateWithinGracePeriod = now.minusSeconds(gracePeriod - 150)
 
-  it should s"detect for removal: Nodepool in status $removableStatuses status with app in DELETED status BEYOND grace period" in {
+  it should s"detect for removal: Nodepool in status $removableStatuses status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -68,7 +66,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should s"detect for removal: Nodepool in $removableStatuses status with app in ERROR status BEYOND grace period" in {
+  it should s"detect for removal: Nodepool in $removableStatuses status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -93,7 +91,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should "not detect for removal: default nodepool" in {
+  it should "not detect for removal: default nodepool" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -108,7 +106,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should "NOT detect for removal: Nodepool in DELETED status" in {
+  it should "NOT detect for removal: Nodepool in DELETED status" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -133,7 +131,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in RUNNING status" in {
+  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in RUNNING status" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -159,7 +157,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in DELETED status WITHIN grace period" in {
+  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -185,7 +183,7 @@ class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
     }
   }
 
-  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in ERROR status WITHIN grace period" in {
+  it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
@@ -3,55 +3,55 @@ package resourceValidator
 
 import com.broadinstitute.dsp.DBTestHelper._
 import doobie.scalatest.IOChecker
-import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 
 /**
  * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
  * For running these tests locally, you can
  *   * Start leonardo mysql container locally
- *   * Comment out https://github.com/DataBiosphere/leonardo/blob/develop/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala#L82
- *   * Run a database unit test in leonardo
+ *   * Run a database unit test in leonardo (this will set up database schema properly)
  *   * Run this spec
  */
-@DoNotDiscover
 final class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 
-  it should "build deletedDisksQuery properly" in {
+  it should "build deletedDisksQuery properly" taggedAs (DbTest) in {
     check(DbReader.deletedDisksQuery)
   }
 
-  it should "build initBucketsToDeleteQuery properly" in {
+  it should "build initBucketsToDeleteQuery properly" taggedAs (DbTest) in {
     check(DbReader.initBucketsToDeleteQuery)
   }
 
-  it should "build deletedRuntimeQuery properly" in {
+  it should "build deletedRuntimeQuery properly" taggedAs (DbTest) in {
     check(DbReader.deletedRuntimeQuery)
   }
 
-  it should "build erroredRuntimeQuery properly" in {
+  it should "build erroredRuntimeQuery properly" taggedAs (DbTest) in {
     check(DbReader.erroredRuntimeQuery)
   }
 
-  it should "build stoppedRuntimeQuery properly" in {
+  it should "build stoppedRuntimeQuery properly" taggedAs (DbTest) in {
     check(DbReader.stoppedRuntimeQuery)
   }
 
-  it should "build kubernetesClustersToDeleteQuery properly" in {
+  it should "build kubernetesClustersToDeleteQuery properly" taggedAs (DbTest) in {
     check(DbReader.kubernetesClustersToDeleteQuery)
   }
 
-  it should "build deletedAndErroredKubernetesClusterQuery properly" in {
+  it should "build deletedAndErroredKubernetesClusterQuery properly" taggedAs (DbTest) in {
     check(DbReader.deletedAndErroredKubernetesClusterQuery)
   }
 
-  it should "build deletedAndErroredNodepoolQuery properly" in {
+  it should "build deletedAndErroredNodepoolQuery properly" taggedAs (DbTest) in {
     check(DbReader.deletedAndErroredNodepoolQuery)
   }
 
-  it should "build dataprocClusterWithWorkersQuery properly" in {
+  // This test will fail because region is an optional field, and we're trying to read it as non optional field.
+  // But this is okay in reality because if we're reading it as `Dataproc` runtime, region should always exist;
+  // and we should get a runtime exception if there's a polluted data in DB.
+  it should "build dataprocClusterWithWorkersQuery properly" ignore {
     check(DbReader.dataprocClusterWithWorkersQuery)
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -6,15 +6,13 @@ import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 
-@DoNotDiscover
 class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 
-  it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" in {
+  it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -12,15 +12,13 @@ import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 
-@DoNotDiscover
 class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 
-  it should "detect nodepools that are Deleted or Errored in the Leo DB" in {
+  it should "detect nodepools that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -8,18 +8,15 @@ import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
-import org.scalatest.DoNotDiscover
 import org.scalatest.flatspec.AnyFlatSpec
 
 /**
  * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
  * For running these tests locally, you can
  *   * Start leonardo mysql container locally
- *   * Comment out https://github.com/DataBiosphere/leonardo/blob/develop/http/src/test/scala/org/broadinstitute/dsde/workbench/leonardo/db/TestComponent.scala#L82
  *   * Run a database unit test in leonardo
  *   * Run this spec
  */
-@DoNotDiscover
 final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
@@ -33,7 +30,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   val destroyedDateBeyondGracePeriod = now.minusSeconds(gracePeriod + 200)
   val destroyedDateWithinGracePeriod = now.minusSeconds(gracePeriod - 150)
 
-  it should "detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status BEYOND grace period" in {
+  it should "detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -59,7 +56,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status BEYOND grace period" in {
+  it should "detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -84,7 +81,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "detect for removal: Kubernetes cluster in RUNNING status with only a default nodepool and no apps" in {
+  it should "detect for removal: Kubernetes cluster in RUNNING status with only a default nodepool and no apps" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -99,7 +96,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "NOT detect for removal: Kubernetes cluster in DELETED status" in {
+  it should "NOT detect for removal: Kubernetes cluster in DELETED status" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -124,7 +121,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in RUNNING status" in {
+  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in RUNNING status" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -150,7 +147,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status WITHIN grace period" in {
+  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -176,7 +173,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
     }
   }
 
-  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status WITHIN grace period" in {
+  it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -202,7 +199,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   // The scenario below is to mimic a cluster with batch-pre-created nodepools, which we don't want to auto-delete
-  it should "NOT detect for removal: Kubernetes cluster with nodepools but no apps" in {
+  it should "NOT detect for removal: Kubernetes cluster with nodepools but no apps" taggedAs DbTest in {
     forAll { (cluster: KubernetesClusterId) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -88,7 +88,8 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   }
 
   it should "return None if dataproc cluster still exists in Google in Error status and it is not a dry run" in {
-    forAll { (runtime: Runtime) =>
+    implicit val arbA = arbDataprocRuntime
+    forAll { (runtime: Runtime.Dataproc) =>
       val dbReader = new FakeDbReader {
         override def getErroredRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
       }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
@@ -3,7 +3,6 @@ package resourceValidator
 
 import cats.effect.IO
 import cats.mtl.Ask
-import com.broadinstitute.dsp.CloudService.Dataproc
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper._
 import com.google.cloud.compute.v1.{Instance, Operation}
@@ -104,11 +103,10 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
   }
 
   it should "return None if Dataproc cluster is RUNNING but its instances are STOPPED" in {
-    forAll { (runtime: Runtime, dryRun: Boolean) =>
-      val dataprocRuntime = runtime.copy(cloudService = Dataproc)
-
+    implicit val arbA = arbDataprocRuntime
+    forAll { (runtime: Runtime.Dataproc, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
-        override def getStoppedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(dataprocRuntime)
+        override def getStoppedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
       }
 
       val computeService = new FakeGoogleComputeService {

--- a/zombie-monitor/cloudbuild.yaml
+++ b/zombie-monitor/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - name: 'gcr.io/$PROJECT_ID/scala-sbt'
     args:
       - |
-        test; zombieMonitor/docker:publishLocal
+        testOnly -- -l cronJobs.dbTest; zombieMonitor/docker:publishLocal
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'image', 'tag', 'us.gcr.io/broad-dsp-gcr-public/zombie-monitor:latest', 'us.gcr.io/broad-dsp-gcr-public/zombie-monitor:$SHORT_SHA']
 images: [

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Config.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Config.scala
@@ -3,7 +3,7 @@ package zombieMonitor
 
 import java.nio.file.Path
 
-import cats.implicits._
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import pureconfig._
 import pureconfig.generic.auto._

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -6,7 +6,7 @@ import fs2.Stream
 import DbReaderImplicits._
 import doobie._
 import doobie.implicits._
-import cats.implicits._
+import cats.syntax.all._
 
 trait DbReader[F[_]] {
   def getDisksToDeleteCandidate: Stream[F, Disk]
@@ -34,9 +34,10 @@ object DbReader {
   // We only check runtimes that have been created for more than 1 hour because a newly "Creating" runtime may not exist in Google yet
   val activeRuntimeQuery =
     sql"""
-         SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status FROM CLUSTER AS c1
-         INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
-         WHERE c1.status!="Deleted" AND c1.status!="Error" AND createdDate < now() - INTERVAL 1 HOUR
+         SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.zone, rt.region
+            FROM CLUSTER AS c1
+            INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
+            WHERE c1.status!="Deleted" AND c1.status!="Error" AND createdDate < now() - INTERVAL 1 HOUR
         """.query[Runtime]
 
   val activeK8sClustersQuery =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -2,10 +2,10 @@ package com.broadinstitute.dsp
 package zombieMonitor
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 /**
@@ -26,7 +26,7 @@ object DeletedDiskChecker {
 
       def checkResource(disk: Disk, isDryRun: Boolean)(implicit ev: Ask[F, TraceId]): F[Option[Disk]] =
         for {
-          diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, zoneName, disk.diskName)
+          diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, defaultZoneNameForDiskOnly, disk.diskName)
           _ <- if (isDryRun) F.unit
           else
             diskOpt match {

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -4,9 +4,9 @@ package zombieMonitor
 import cats.effect.{Concurrent, Timer}
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
-import cats.implicits._
+import cats.syntax.all._
 
 /**
  * Similar to `DeletedDiskChecker`, but this process all non deleted k8s clusters and check if they still exists in google.

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
@@ -2,10 +2,10 @@ package com.broadinstitute.dsp
 package zombieMonitor
 
 import cats.effect.{Concurrent, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 /**

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp.zombieMonitor
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import com.monovore.decline.{CommandApp, _}
 import scala.concurrent.ExecutionContext.global
 

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -8,8 +8,8 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, Concurrent, ConcurrentEffect, ContextShift, ExitCode, Resource, Sync, Timer}
 import cats.mtl.Ask
 import fs2.Stream
-import io.chrisdavenport.log4cats.StructuredLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.google2.{GKEService, GoogleDiskService}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeCheckerSpec.scala
@@ -89,8 +89,8 @@ class DeletedOrErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSu
   }
 
   it should "report a runtime if it still exists in google in ERROR and is active in leonardo DB" in {
-    forAll { (rt: Runtime, dryRun: Boolean) =>
-      val runtime = rt.copy(cloudService = CloudService.Dataproc)
+    implicit val arbA = arbDataprocRuntime
+    forAll { (runtime: Runtime.Dataproc, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getRuntimeCandidate: Stream[IO, Runtime] =
           Stream.emit(runtime)
@@ -116,8 +116,8 @@ class DeletedOrErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSu
   }
 
   it should "mark cluster as Deleted if billing is disabled" in {
-    forAll { (rt: Runtime, dryRun: Boolean) =>
-      val runtime = rt.copy(cloudService = CloudService.Dataproc)
+    implicit val arbA = arbDataprocRuntime
+    forAll { (runtime: Runtime.Dataproc, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getRuntimeCandidate: Stream[IO, Runtime] =
           Stream.emit(runtime)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2589

* Add multi zone and region support. Since disk zone is not persisted yet, so there're still a few default zone references left. Those should be addressed after https://broadworkbench.atlassian.net/browse/IA-2640
* Added `cronJobs.dbTest` for running all DB access unit tests. Altho, tests don't seem to pass when running at the same time due to some errors like. All db unit tests are passing when running separately. Will log a separate ticket to figure out how these DB tests can be run together.
```
Cannot add or update a child row: a foreign key constraint fails (`leotestdb`.`NODEPOOL`, CONSTRAINT `FK_NODEPOOL_CLUSTER_ID` FOREIGN KEY (`clusterId`) REFERENCES `KUBERNETES_CLUSTER` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION)
```