### PR TITLE
Update Resource Validator to handle the 2nd Galaxy disk (IA-2741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,22 @@ e.g. `sbt "resourceValidator/run --dryRun --all"`
 
 ## Contributing
 
-Currently, `com.broadinstitute.dsp.zombieMonitor.DbReaderSpec` and `com.broadinstitute.dsp.resourceValidator.DbReaderSpec` are not run in CI, hence make sure you run them manually before merging any PRs.
+1. Run these unit tests locally before making a PR:
+- `com.broadinstitute.dsp.zombieMonitor.DbReaderSpec` 
+- `com.broadinstitute.dsp.resourceValidator.DbReaderSpec`
 
-Once a PR is merged, there will be a PR created in [terra-helm](https://github.com/broadinstitute/terra-helm). 
-Get this PR merged, and another automatic commit will bump leonardo's chart version. This will trigger another automatic commit 
-in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile), note this commit will only auto bump `dev` and `perf`, and will be auto-merged. Once the terra-helmfile PR is auto-merged, go to [argo](https://ap-argocd.dsp-devops.broadinstitute.org/applications) (you need to be on VPN to access argo), and click `SYNC APPS` button on the left upper corner for dev and perf leonardo deploys (select `PRUNE` option as well).
-this will sync leonardo's deployment to match [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo.
-the chartVersion bump and sync for other environments will happen automatically when there is a Terra monolith release.
+   These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
+
+2. Once your PR is approved you can merge it and a new PR will be automatically created in [terra-helm](https://github.com/broadinstitute/terra-helm). 
+
+3. Get this terra-helm PR merged (you can merge it yourself) and another automatic commit will bump leonardo's chart version. This will trigger another automatic commit 
+in [terra-helmfile](https://github.com/broadinstitute/terra-helmfile). Note that this commit will only auto-bump `dev` and `perf`, and will be auto-merged.
+
+4. Once the terra-helmfile PR is auto-merged, go to [argo](https://ap-argocd.dsp-devops.broadinstitute.org/applications) (you need to be on VPN to access argo), and click the `SYNC APPS` button on the left upper corner. Select these boxes to sync:
+ - `leonardo dev` 
+ - `leonardo perf`
+ - `prune`
+    
+    This will sync leonardo's deployment to match [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repo.
+    the chartVersion bump and sync for other environments will happen automatically when there is a Terra monolith release.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ docker run \
 ```
 .
 ## Set up configuration file
-Copy `application.conf.example` under each project in dir `[project]/src/main/resources` as `application.conf`. Replace values properly.
+Copy `application.conf.example` under each project in dir `[project]/src/main/resources` as `application.conf`. Replace values appropriately.
+i.e. the `leonardo-pubsub.google-project`  will need to be one that the user you are configured as will have access to.
+
 
 ## Run a job
 ```
@@ -52,7 +54,7 @@ e.g. `sbt "resourceValidator/run --dryRun --all"`
 
 1. Run these unit tests locally before making a PR:
 - `com.broadinstitute.dsp.zombieMonitor.DbReaderSpec` 
-- `com.broadinstitute.dsp.resourceValidator.DbReaderSpec`
+- `com.broadinstitute.dsp.resourceValidator.DbQueryBuilderSpec`
 
    These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
 

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -24,7 +24,11 @@ object CloudService {
     override def asString: String = "DATAPROC"
   }
 }
-final case class Disk(id: Long, googleProject: GoogleProject, diskName: DiskName, formattedBy: Option[String]) {
+final case class Disk(id: Long,
+                      googleProject: GoogleProject,
+                      diskName: DiskName,
+                      formattedBy: Option[String],
+                      release: Option[String]) {
   override def toString: String = s"${id}/${googleProject.value},${diskName.value}"
 }
 

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -24,7 +24,7 @@ object CloudService {
     override def asString: String = "DATAPROC"
   }
 }
-final case class Disk(id: Long, googleProject: GoogleProject, diskName: DiskName) {
+final case class Disk(id: Long, googleProject: GoogleProject, diskName: DiskName, formattedBy: Option[String]) {
   override def toString: String = s"${id}/${googleProject.value},${diskName.value}"
 }
 

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -27,9 +27,8 @@ object CloudService {
 final case class Disk(id: Long,
                       googleProject: GoogleProject,
                       diskName: DiskName,
-                      zone: ZoneName
-                      formattedBy: Option[String],
-                      release: Option[String]) {
+                      zone: ZoneName,
+                      formattedBy: Option[String]) {
   override def toString: String = s"${id}/${googleProject.value},${diskName.value},${zone.value}"
 }
 

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -34,7 +34,7 @@ object Generators {
     diskName <- genDiskName
     zone <- genZoneName
   } yield {
-    Disk(id, project, diskName, zone, formattedBy = None, release = None)
+    Disk(id, project, diskName, zone, formattedBy = None)
   }
 
   val genInitBucket: Gen[InitBucketToRemove] = for {

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -34,7 +34,7 @@ object Generators {
     diskName <- genDiskName
     zone <- genZoneName
   } yield {
-    Disk(id, project, diskName, zone, formattedBy = None)
+    Disk(id, project, diskName, zone, formattedBy = Some("GCE"))
   }
 
   val genInitBucket: Gen[InitBucketToRemove] = for {

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -17,7 +17,7 @@ object Generators {
     id <- Gen.chooseNum(0, 100)
     project <- genGoogleProject
     diskName <- genDiskName
-  } yield Disk(id, project, diskName, formattedBy = None)
+  } yield Disk(id, project, diskName, formattedBy = None, release = None)
 
   val genInitBucket: Gen[InitBucketToRemove] = for {
     project <- genGoogleProject

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -17,7 +17,7 @@ object Generators {
     id <- Gen.chooseNum(0, 100)
     project <- genGoogleProject
     diskName <- genDiskName
-  } yield Disk(id, project, diskName)
+  } yield Disk(id, project, diskName, formattedBy = None)
 
   val genInitBucket: Gen[InitBucketToRemove] = for {
     project <- genGoogleProject

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -29,7 +29,7 @@ object DbReader {
 
   val deletedDisksQuery =
     sql"""
-           select pd1.id, pd1.googleProject, pd1.name, pd1.zone, pd1.formattedBy, pd1.release
+           select pd1.id, pd1.googleProject, pd1.name, pd1.zone, pd1.formattedBy
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
              NOT EXISTS
@@ -177,8 +177,8 @@ object DbReader {
     sql"""SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.region, rt.numberOfWorkers, rt.numberOfPreemptibleWorkers
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
-          WHERE 
-            rt.cloudService="DATAPROC" AND 
+          WHERE
+            rt.cloudService="DATAPROC" AND
             NOT c1.status="DELETED" AND
             c1.id != 6220
          """

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -29,10 +29,9 @@ object DbReader {
 
   val deletedDisksQuery =
     sql"""
-           select pd1.id, pd1.googleProject, pd1.name, pd1.formattedBy
+           select pd1.id, pd1.googleProject, pd1.name, pd1.formattedBy, pd1.release
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
-             pd1.destroyedDate > now() - INTERVAL 30 DAY AND
              NOT EXISTS
              (
                SELECT *

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -29,7 +29,7 @@ object DbReader {
 
   val deletedDisksQuery =
     sql"""
-           select pd1.id, pd1.googleProject, pd1.name
+           select pd1.id, pd1.googleProject, pd1.name, pd1.formattedBy
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
              pd1.destroyedDate > now() - INTERVAL 30 DAY AND

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -32,6 +32,7 @@ object DbReader {
            select pd1.id, pd1.googleProject, pd1.name, pd1.zone, pd1.formattedBy
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
+           pd1.destroyedDate > now() - INTERVAL 30 DAY AND
              NOT EXISTS
              (
                SELECT *

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -28,14 +28,15 @@ object DeletedDiskChecker {
           diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, disk.zone, disk.diskName)
           _ <- if (!isDryRun) {
             if (disk.formattedBy.getOrElse(None) == "GALAXY") {
-              val releaseStringThing = disk.release.toString.split('-')(0)
-              val postgresDiskName = DiskName(s"${releaseStringThing}-gxy-ns-postres-disk")
+              val dataDiskName = disk.diskName
+              val postgresDiskName = DiskName(s"${dataDiskName}-gxy-ns-postres-disk")
               diskOpt.traverse { _ =>
                 List(postgresDiskName, disk.diskName).parTraverse(dn =>
                   deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, dn)
                 )
               }
-            } else diskOpt.traverse(_ => deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, disk.diskName))
+            } else
+              diskOpt.traverse(_ => deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, disk.diskName))
           } else F.pure(None)
         } yield diskOpt.map(_ => disk)
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -29,7 +29,7 @@ object DeletedDiskChecker {
           _ <- if (!isDryRun) {
             if (disk.formattedBy.getOrElse(None) == "GALAXY") {
               val dataDiskName = disk.diskName
-              val postgresDiskName = DiskName(s"${dataDiskName}-gxy-ns-postres-disk")
+              val postgresDiskName = DiskName(s"${dataDiskName}-gxy-postres-disk")
               diskOpt.traverse { _ =>
                 List(postgresDiskName, disk.diskName).parTraverse(dn =>
                   deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, dn)

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -29,9 +29,9 @@ object DeletedDiskChecker {
           _ <- if (!isDryRun) {
             if (disk.formattedBy.getOrElse(None) == "GALAXY") {
               val dataDiskName = disk.diskName
-              val postgresDiskName = DiskName(s"${dataDiskName}-gxy-postres-disk")
+              val postgresDiskName = DiskName(s"${dataDiskName.value}-gxy-postres-disk")
               diskOpt.traverse { _ =>
-                List(postgresDiskName, disk.diskName).parTraverse(dn =>
+                List(postgresDiskName, dataDiskName).parTraverse(dn =>
                   deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, dn)
                 )
               }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -28,7 +28,7 @@ object DbReader {
   implicit def apply[F[_]](implicit ev: DbReader[F]): DbReader[F] = ev
 
   val activeDisksQuery =
-    sql"""select id, googleProject, name, zone from PERSISTENT_DISK where status != "Deleted" and status != "Error";
+    sql"""select id, googleProject, name, zone, formattedBy from PERSISTENT_DISK where status != "Deleted" and status != "Error";
         """.query[Disk]
 
   // We only check runtimes that have been created for more than 1 hour because a newly "Creating" runtime may not exist in Google yet


### PR DESCRIPTION
Update ResourceValidator to delete metadata disks from Google if cleaning up the corresponding data disk. Relies on this PR for Leo (https://github.com/DataBiosphere/leonardo/pull/2069) to update the naming convention for Galaxy metadata disks to be discoverable using the PERSISTENT_DISK table in the Leo DB.


Tested successfully on dev
Made a Galaxy app then detached the disks in Google and set them to "deleted" status in the DB. Ran the cronjob and both disks were deleted from Google
Before:
<img width="1333" alt="Screen Shot 2021-05-19 at 4 01 08 PM" src="https://user-images.githubusercontent.com/54322292/118877202-2344b580-b8bc-11eb-9497-d4269c9236ca.png">
After:
<img width="986" alt="Screen Shot 2021-05-19 at 4 02 13 PM" src="https://user-images.githubusercontent.com/54322292/118877214-26d83c80-b8bc-11eb-880a-b81f07a72937.png">
