### PR TITLE
IA-2977 fix bugs from DB refactoring

### DIFF
--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -92,7 +92,7 @@ object DbReader {
    */
   val stagingBucketsToDeleteQuery =
     sql"""
-        SELECT googleProject, stagingBucket
+        SELECT cloudContext, stagingBucket
         FROM CLUSTER
         WHERE
           status="Deleted" AND

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -28,13 +28,13 @@ object DbReader {
   implicit def apply[F[_]](implicit ev: DbReader[F]): DbReader[F] = ev
 
   val activeDisksQuery =
-    sql"""select id, googleProject, name, zone, formattedBy from PERSISTENT_DISK where status != "Deleted" and status != "Error";
+    sql"""select id, cloudContext, name, zone, formattedBy from PERSISTENT_DISK where status != "Deleted" and status != "Error";
         """.query[Disk]
 
   // We only check runtimes that have been created for more than 1 hour because a newly "Creating" runtime may not exist in Google yet
   val activeRuntimeQuery =
     sql"""
-         SELECT DISTINCT c1.id, googleProject, clusterName, rt.cloudService, c1.status, rt.zone, rt.region
+         SELECT DISTINCT c1.id, cloudContext, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
             FROM CLUSTER AS c1
             INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
             WHERE c1.status!="Deleted" AND c1.status!="Error" AND createdDate < now() - INTERVAL 1 HOUR


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2977

Part of the refactoring to support Azure, `clusterRuntime` is renamed to `runtimeName`, `googleProject` is renamed to `cloudContext` for CLUSTER, and PD tables