### PR TITLE
IA-3005  update dataproc cluster to fully stop clusters

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -1,13 +1,13 @@
 package com.broadinstitute.dsp
 
 import cats.syntax.all._
+import doobie.implicits.javasql.TimestampMeta
 import doobie.{Get, Meta, Read}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterName
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
-import doobie.implicits.javasql.TimestampMeta
 
-import java.sql.Timestamp
+import java.sql.{SQLDataException, Timestamp}
 import java.time.Instant
 
 object DbReaderImplicits {
@@ -25,35 +25,53 @@ object DbReaderImplicits {
   implicit val diskNameMeta: Meta[DiskName] = Meta[String].imap(DiskName)(_.value)
   implicit val zoneNameMeta: Meta[ZoneName] = Meta[String].imap(ZoneName(_))(_.value)
   implicit val googleProjectMeta: Meta[GoogleProject] = Meta[String].imap(GoogleProject)(_.value)
+  implicit val cloudProviderMeta: Meta[CloudProvider] = Meta[String].imap(s =>
+    CloudProvider.stringToCloudProvider.get(s).getOrElse(throw new SQLDataException(s"Invalid cloud provider ${s}")))(_.asString)
   implicit val k8sClusterNameMeta: Meta[KubernetesClusterName] = Meta[String].imap(KubernetesClusterName)(_.value)
   implicit val locationMeta: Meta[Location] = Meta[String].imap(Location)(_.value)
   implicit val regionNameMeta: Meta[RegionName] = Meta[String].imap(RegionName(_))(_.value)
+
+  implicit val cloudContextRead: Read[CloudContext] = Read[(String, CloudProvider)].map {
+    case (s, cloudProvider) =>
+      cloudProvider match {
+        case CloudProvider.Azure =>
+          CloudContext.Azure(s)
+        case CloudProvider.Gcp =>
+          CloudContext.Gcp(GoogleProject(s))
+      }
+  }
+
   implicit val runtimeRead: Read[Runtime] =
-    Read[(Long, GoogleProject, String, CloudService, String, Option[ZoneName], Option[RegionName])].map {
-      case (id, project, runtimeName, cloudService, status, zone, region) =>
-        (zone, region) match {
-          case (Some(_), Some(_)) =>
-            throw new RuntimeException(
-              s"${cloudService} Runtime ${id} has both zone and region defined. This is impossible. Fix this in DB"
-            )
-          case (Some(z), None) =>
-            if (cloudService == CloudService.Gce)
-              Runtime.Gce(id, project, runtimeName, cloudService, status, z)
-            else
-              throw new RuntimeException(
-                s"Dataproc runtime ${id} has no region defined. This is impossible. Fix this in DB"
-              )
-          case (None, Some(r)) =>
-            if (cloudService == CloudService.Dataproc)
-              Runtime.Dataproc(id, project, runtimeName, cloudService, status, r)
-            else
-              throw new RuntimeException(
-                s"Gce runtime ${id} has no zone defined. This is impossible. Fix this in DB"
-              )
-          case (None, None) =>
-            throw new RuntimeException(
-              s"${cloudService} Runtime ${id} has no zone and no region defined. This is impossible. Fix this in DB"
-            )
+    Read[(Long, String, CloudProvider, String, CloudService, String, Option[ZoneName], Option[RegionName])].map {
+      case (id, cloudContextDb, cloudProvider, runtimeName, cloudService, status, zone, region) =>
+        cloudProvider match {
+          case CloudProvider.Azure =>
+            throw new NotImplementedError()
+          case CloudProvider.Gcp =>
+            (zone, region) match {
+              case (Some(_), Some(_)) =>
+                throw new RuntimeException(
+                  s"${cloudService} Runtime ${id} has both zone and region defined. This is impossible. Fix this in DB"
+                )
+              case (Some(z), None) =>
+                if (cloudService == CloudService.Gce)
+                  Runtime.Gce(id, GoogleProject(cloudContextDb), runtimeName, cloudService, status, z)
+                else
+                  throw new RuntimeException(
+                    s"Dataproc runtime ${id} has no region defined. This is impossible. Fix this in DB"
+                  )
+              case (None, Some(r)) =>
+                if (cloudService == CloudService.Dataproc)
+                  Runtime.Dataproc(id, GoogleProject(cloudContextDb), runtimeName, cloudService, status, r)
+                else
+                  throw new RuntimeException(
+                    s"Gce runtime ${id} has no zone defined. This is impossible. Fix this in DB"
+                  )
+              case (None, None) =>
+                throw new RuntimeException(
+                  s"${cloudService} Runtime ${id} has no zone and no region defined. This is impossible. Fix this in DB"
+                )
+            }
         }
     }
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -26,19 +26,19 @@ object DbReaderImplicits {
   implicit val zoneNameMeta: Meta[ZoneName] = Meta[String].imap(ZoneName(_))(_.value)
   implicit val googleProjectMeta: Meta[GoogleProject] = Meta[String].imap(GoogleProject)(_.value)
   implicit val cloudProviderMeta: Meta[CloudProvider] = Meta[String].imap(s =>
-    CloudProvider.stringToCloudProvider.get(s).getOrElse(throw new SQLDataException(s"Invalid cloud provider ${s}")))(_.asString)
+    CloudProvider.stringToCloudProvider.get(s).getOrElse(throw new SQLDataException(s"Invalid cloud provider ${s}"))
+  )(_.asString)
   implicit val k8sClusterNameMeta: Meta[KubernetesClusterName] = Meta[String].imap(KubernetesClusterName)(_.value)
   implicit val locationMeta: Meta[Location] = Meta[String].imap(Location)(_.value)
   implicit val regionNameMeta: Meta[RegionName] = Meta[String].imap(RegionName(_))(_.value)
 
-  implicit val cloudContextRead: Read[CloudContext] = Read[(String, CloudProvider)].map {
-    case (s, cloudProvider) =>
-      cloudProvider match {
-        case CloudProvider.Azure =>
-          CloudContext.Azure(s)
-        case CloudProvider.Gcp =>
-          CloudContext.Gcp(GoogleProject(s))
-      }
+  implicit val cloudContextRead: Read[CloudContext] = Read[(String, CloudProvider)].map { case (s, cloudProvider) =>
+    cloudProvider match {
+      case CloudProvider.Azure =>
+        CloudContext.Azure(s)
+      case CloudProvider.Gcp =>
+        CloudContext.Gcp(GoogleProject(s))
+    }
   }
 
   implicit val runtimeRead: Read[Runtime] =

--- a/core/src/main/scala/com/broadinstitute/dsp/DbTransactor.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbTransactor.scala
@@ -1,11 +1,11 @@
 package com.broadinstitute.dsp
 
-import cats.effect.{Async, Blocker, ContextShift, Resource}
+import cats.effect.{Async, Resource}
 import doobie.ExecutionContexts
 import doobie.hikari.HikariTransactor
 
 object DbTransactor {
-  def init[F[_]: Async: ContextShift](databaseConfig: DatabaseConfig): Resource[F, HikariTransactor[F]] =
+  def init[F[_]: Async](databaseConfig: DatabaseConfig): Resource[F, HikariTransactor[F]] =
     for {
       fixedThreadPool <- ExecutionContexts.fixedThreadPool(100)
       cachedThreadPool <- ExecutionContexts.cachedThreadPool
@@ -14,8 +14,7 @@ object DbTransactor {
         databaseConfig.url,
         databaseConfig.user,
         databaseConfig.password,
-        fixedThreadPool, // await connection here
-        Blocker.liftExecutionContext(cachedThreadPool)
+        fixedThreadPool
       )
     } yield xa
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -41,7 +41,7 @@ object RuntimeCheckerDeps {
 
 sealed abstract class Runtime {
   def id: Long
-  def googleProject: GoogleProject
+  def cloudContext: CloudContext
   def runtimeName: String
   def cloudService: CloudService
   def status: String
@@ -57,6 +57,8 @@ object Runtime {
   ) extends Runtime {
     // this is the format we'll output in report, which can be easily consumed by scripts if necessary
     override def toString: String = s"$id,${googleProject.value},$runtimeName,$cloudService,$status,${zone.value}"
+
+    override def cloudContext: CloudContext = CloudContext.Gcp(googleProject)
   }
 
   final case class Dataproc(id: Long,
@@ -68,6 +70,7 @@ object Runtime {
   ) extends Runtime {
     // this is the format we'll output in report, which can be easily consumed by scripts if necessary
     override def toString: String = s"$id,${googleProject.value},$runtimeName,$cloudService,$status,${region.value}"
+    override def cloudContext: CloudContext = CloudContext.Gcp(googleProject)
   }
 
   def setStatus(runtime: Runtime, newStatus: String): Runtime = runtime match {

--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -4,7 +4,17 @@ import cats.Parallel
 import cats.effect.std.Semaphore
 import cats.effect.{Async, Resource}
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
-import org.broadinstitute.dsde.workbench.google2.{GKEService, GoogleBillingService, GoogleComputeService, GoogleDataprocService, GoogleDiskService, GooglePublisher, GoogleStorageService, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{
+  GKEService,
+  GoogleBillingService,
+  GoogleComputeService,
+  GoogleDataprocService,
+  GoogleDiskService,
+  GooglePublisher,
+  GoogleStorageService,
+  RegionName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.StructuredLogger
@@ -23,10 +33,7 @@ object RuntimeCheckerDeps {
                                                             blockerBound,
                                                             RetryPredicates.standardGoogleRetryConfig
       )
-      storageService <- GoogleStorageService.resource(config.pathToCredential.toString,
-                                                      Some(blockerBound),
-                                                      None
-      )
+      storageService <- GoogleStorageService.resource(config.pathToCredential.toString, Some(blockerBound), None)
       dataprocService <- GoogleDataprocService.fromCredential(computeService,
                                                               scopedCredential,
                                                               supportedRegions,

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -3,7 +3,12 @@ package com.broadinstitute.dsp
 import ca.mrvisser.sealerate
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, ZoneName}
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName, NodepoolId, NodepoolName}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{
+  KubernetesClusterId,
+  KubernetesClusterName,
+  NodepoolId,
+  NodepoolName
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}
@@ -91,7 +96,6 @@ object RemovableNodepoolStatus {
   val stringToStatus: Map[String, RemovableNodepoolStatus] =
     sealerate.collect[RemovableNodepoolStatus].map(a => (a.asString, a)).toMap
 }
-
 
 sealed abstract class CloudProvider extends Product with Serializable {
   def asString: String

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -3,12 +3,7 @@ package com.broadinstitute.dsp
 import ca.mrvisser.sealerate
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, ZoneName}
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{
-  KubernetesClusterId,
-  KubernetesClusterName,
-  NodepoolId,
-  NodepoolName
-}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName, NodepoolId, NodepoolName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}
@@ -25,12 +20,12 @@ object CloudService {
   }
 }
 final case class Disk(id: Long,
-                      googleProject: GoogleProject,
+                      cloudContext: CloudContext,
                       diskName: DiskName,
                       zone: ZoneName,
                       formattedBy: Option[String]
 ) {
-  override def toString: String = s"${id}/${googleProject.value},${diskName.value},${zone.value}"
+  override def toString: String = s"${id}/${cloudContext.asStringWithProvider},${diskName.value},${zone.value}"
 }
 
 //init buckets are different than staging buckets because we store them with gs://[GcsBucketName]/
@@ -95,6 +90,39 @@ object RemovableNodepoolStatus {
   val removableStatuses = sealerate.values[RemovableNodepoolStatus]
   val stringToStatus: Map[String, RemovableNodepoolStatus] =
     sealerate.collect[RemovableNodepoolStatus].map(a => (a.asString, a)).toMap
+}
+
+
+sealed abstract class CloudProvider extends Product with Serializable {
+  def asString: String
+}
+object CloudProvider {
+  final case object Gcp extends CloudProvider {
+    override val asString = "GCP"
+  }
+  final case object Azure extends CloudProvider {
+    override val asString = "AZURE"
+  }
+
+  val stringToCloudProvider = sealerate.values[CloudProvider].map(p => (p.asString, p)).toMap
+}
+
+sealed abstract class CloudContext extends Product with Serializable {
+  def asString: String
+  def asStringWithProvider: String
+  def cloudProvider: CloudProvider
+}
+object CloudContext {
+  final case class Gcp(value: GoogleProject) extends CloudContext {
+    override val asString = value.value
+    override val asStringWithProvider = s"Gcp/${value.value}"
+    override def cloudProvider: CloudProvider = CloudProvider.Gcp
+  }
+  final case class Azure(value: String) extends CloudContext {
+    override val asString = value
+    override val asStringWithProvider = s"Azure/${value}"
+    override def cloudProvider: CloudProvider = CloudProvider.Azure
+  }
 }
 
 object JsonCodec {

--- a/core/src/main/scala/com/broadinstitute/dsp/package.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/package.scala
@@ -1,6 +1,6 @@
 package com.broadinstitute
 
-import cats.effect.{Resource, Sync, Timer}
+import cats.effect.{Resource, Sync}
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import org.broadinstitute.dsde.workbench.google2.RegionName
 
@@ -36,7 +36,7 @@ package object dsp {
     "australia-southeast1"
   ).map(s => RegionName(s))
 
-  def initGoogleCredentials[F[_]: Sync: Timer](
+  def initGoogleCredentials[F[_]: Sync](
     pathToCredential: Path
   ): Resource[F, GoogleCredentials] =
     for {

--- a/core/src/test/scala/com/broadinstitute/dsp/CronJobsTestSuite.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/CronJobsTestSuite.scala
@@ -1,24 +1,21 @@
 package com.broadinstitute.dsp
 
-import cats.effect.{Blocker, ContextShift, IO, Timer}
+import cats.effect.IO
 import cats.mtl.Ask
-import org.typelevel.log4cats.StructuredLogger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.log4cats.StructuredLogger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
 import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.global
 
 trait CronJobsTestSuite extends Matchers with ScalaCheckPropertyChecks with Configuration {
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
-  implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
-  implicit val timer: Timer[IO] = IO.timer(executionContext)
   implicit val unsafeLogger: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
   val fakeTraceId = TraceId("fakeTraceId")
   implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](fakeTraceId)
-  val blocker: Blocker = Blocker.liftExecutionContext(global)
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 3)
 }

--- a/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DBTestHelper.scala
@@ -1,24 +1,24 @@
 package com.broadinstitute.dsp
 
-import java.time.Instant
-import java.util.UUID
-import cats.effect.{ContextShift, IO, Resource}
+import cats.effect.{IO, Resource}
+import doobie.Put
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
-import DbReaderImplicits._
-import doobie.Put
 import doobie.util.transactor.Transactor
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{RegionName, ZoneName}
 import org.scalatest.Tag
+import DbReaderImplicits._
+import java.time.Instant
+import java.util.UUID
 
 object DBTestHelper {
   implicit val cloudServicePut: Put[CloudService] = Put[String].contramap(cloudService => cloudService.asString)
   val zoneName = ZoneName("us-central1-a")
   val regionName = RegionName("us-central1")
 
-  def yoloTransactor(implicit cs: ContextShift[IO], databaseConfig: DatabaseConfig): Transactor[IO] =
+  def yoloTransactor(implicit databaseConfig: DatabaseConfig): Transactor[IO] =
     Transactor.fromDriverManager[IO](
       "com.mysql.cj.jdbc.Driver", // driver classname
       databaseConfig.url,
@@ -27,7 +27,6 @@ object DBTestHelper {
     )
 
   def transactorResource(implicit
-    cs: ContextShift[IO],
     databaseConfig: DatabaseConfig
   ): Resource[IO, HikariTransactor[IO]] =
     for {

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -12,8 +12,7 @@ object Generators {
     cloudService <- genCloudService
     project <- genGoogleProject
     runtimeName <- Gen.uuid.map(_.toString)
-    status <- possibleStatuses.fold(
-      Gen.oneOf("Running", "Creating", "Deleted", "Error"))(s => Gen.oneOf(s.toList))
+    status <- possibleStatuses.fold(Gen.oneOf("Running", "Creating", "Deleted", "Error"))(s => Gen.oneOf(s.toList))
   } yield cloudService match {
     case CloudService.Dataproc =>
       Runtime.Dataproc(id, project, runtimeName, cloudService, status, DBTestHelper.regionName)
@@ -31,7 +30,12 @@ object Generators {
     project <- genGoogleProject
     diskName <- genDiskName
     zone <- genZoneName
-  } yield Disk(id, CloudContext.Gcp(project), diskName, zone, formattedBy = Some("GCE")) //TODO: update generator once we support Azure
+  } yield Disk(id,
+               CloudContext.Gcp(project),
+               diskName,
+               zone,
+               formattedBy = Some("GCE")
+  ) // TODO: update generator once we support Azure
 
   val genInitBucket: Gen[InitBucketToRemove] = for {
     project <- genGoogleProject

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -1,17 +1,19 @@
 package com.broadinstitute.dsp
 
+import cats.data.NonEmptyList
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
 import org.scalacheck.{Arbitrary, Gen}
 import org.broadinstitute.dsde.workbench.google2.Generators._
 
 object Generators {
   val genCloudService: Gen[CloudService] = Gen.oneOf(CloudService.Gce, CloudService.Dataproc)
-  val genRuntime: Gen[Runtime] = for {
+  def genRuntime(possibleStatuses: Option[NonEmptyList[String]]): Gen[Runtime] = for {
     id <- Gen.chooseNum(0, 100)
     cloudService <- genCloudService
     project <- genGoogleProject
     runtimeName <- Gen.uuid.map(_.toString)
-    status <- Gen.oneOf("Running", "Creating", "Deleted", "Error")
+    status <- possibleStatuses.fold(
+      Gen.oneOf("Running", "Creating", "Deleted", "Error"))(s => Gen.oneOf(s.toList))
   } yield cloudService match {
     case CloudService.Dataproc =>
       Runtime.Dataproc(id, project, runtimeName, cloudService, status, DBTestHelper.regionName)
@@ -29,7 +31,7 @@ object Generators {
     project <- genGoogleProject
     diskName <- genDiskName
     zone <- genZoneName
-  } yield Disk(id, project, diskName, zone, formattedBy = Some("GCE"))
+  } yield Disk(id, CloudContext.Gcp(project), diskName, zone, formattedBy = Some("GCE")) //TODO: update generator once we support Azure
 
   val genInitBucket: Gen[InitBucketToRemove] = for {
     project <- genGoogleProject
@@ -76,7 +78,7 @@ object Generators {
   } yield status
 
   val arbDataprocRuntime: Arbitrary[Runtime.Dataproc] = Arbitrary(genDataprocRuntime)
-  implicit val arbRuntime: Arbitrary[Runtime] = Arbitrary(genRuntime)
+  implicit val arbRuntime: Arbitrary[Runtime] = Arbitrary(genRuntime(None))
   implicit val arbCloudService: Arbitrary[CloudService] = Arbitrary(genCloudService)
   implicit val arbDisk: Arbitrary[Disk] = Arbitrary(genDisk)
   implicit val arbInitBucket: Arbitrary[InitBucketToRemove] = Arbitrary(genInitBucket)

--- a/janitor/src/main/resources/reference.conf
+++ b/janitor/src/main/resources/reference.conf
@@ -10,9 +10,11 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
-report-destination-bucket = "replace-me"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 }
+leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against
+
+report-destination-bucket = "qitest" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket

--- a/janitor/src/main/resources/reference.conf
+++ b/janitor/src/main/resources/reference.conf
@@ -10,11 +10,9 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
+report-destination-bucket = "replace-me"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 }
-leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against
-
-report-destination-bucket = "qitest" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import cats.effect.{Async, _}
+import cats.effect.Async
 import doobie._
 import doobie.implicits._
 import fs2.Stream
@@ -101,7 +101,7 @@ object DbReader {
         """
       .query[BucketToRemove]
 
-  def impl[F[_]: ContextShift](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
+  def impl[F[_]](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
     override def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove] =
       kubernetesClustersToDeleteQuery.stream.transact(xa)
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
@@ -3,18 +3,14 @@ package janitor
 
 import cats.effect.IO
 import cats.syntax.all._
-import com.monovore.decline.{CommandApp, _}
-import scala.concurrent.ExecutionContext.global
-
+import com.monovore.decline._
+import cats.effect.unsafe.implicits.global
 object Main
     extends CommandApp(
       name = "janitor",
       header = "Clean up prod resources deemed not utilized",
       version = "0.0.1",
       main = {
-        implicit val cs = IO.contextShift(global)
-        implicit val timer = IO.timer(global)
-
         val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
         val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
@@ -1,18 +1,18 @@
 package com.broadinstitute.dsp
 package janitor
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import org.typelevel.log4cats.Logger
+import cats.syntax.all._
+import com.broadinstitute.dsp.JsonCodec._
 import org.broadinstitute.dsde.workbench.model.TraceId
-import JsonCodec._
+import org.typelevel.log4cats.Logger
 
 object NodepoolRemover {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: LeoPublisherDeps[F]
-  )(implicit F: Concurrent[F], timer: Timer[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Nodepool] =
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Nodepool] =
     new CheckRunner[F, Nodepool] {
       override def appName: String = janitor.appName
       override def configs = CheckRunnerConfigs(s"remove-kubernetes-nodepools", shouldAlert = false)

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StagingBucketRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StagingBucketRemover.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import cats.effect.{Concurrent}
+import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StagingBucketRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StagingBucketRemover.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import cats.effect.{Concurrent, Timer}
+import cats.effect.{Concurrent}
 import cats.mtl.Ask
 import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
@@ -10,12 +10,11 @@ import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.typelevel.log4cats.Logger
 
 object StagingBucketRemover {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: CheckRunnerDeps[F]
   )(implicit
     F: Concurrent[F],
-    timer: Timer[F],
     logger: Logger[F],
     ev: Ask[F, TraceId]
   ): CheckRunner[F, BucketToRemove] =

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DBReaderGetNodepoolsToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DBReaderGetNodepoolsToDeleteSpec.scala
@@ -16,7 +16,7 @@ import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 import java.time.Instant
 
 /**

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -1,9 +1,9 @@
 package com.broadinstitute.dsp
 package janitor
 
+import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DBTestHelper._
 import com.broadinstitute.dsp.Generators._
-import com.broadinstitute.dsp.{CronJobsTestSuite, Disk}
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, Fake
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "send DeleteKubernetesClusterMessage when clusters are detected to be auto-deleted" in {
     forAll { (clusterToRemove: KubernetesClusterToRemove, dryRun: Boolean) =>

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, Fake
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec
+import cats.effect.unsafe.implicits.global
 
 final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "send DeleteNodepoolMessage when nodepools are detected to be auto-deleted" in {

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
@@ -3,8 +3,8 @@ package nuker
 
 import cats.effect.IO
 import cats.syntax.all._
-import com.monovore.decline.{CommandApp, _}
-import scala.concurrent.ExecutionContext.global
+import com.monovore.decline._
+import cats.effect.unsafe.implicits.global
 
 object Main
     extends CommandApp(
@@ -12,9 +12,6 @@ object Main
       header = "Clean up cloud resources created by Leonardo in dev/qa projects",
       version = "0.0.1",
       main = {
-        implicit val cs = IO.contextShift(global)
-        implicit val timer = IO.timer(global)
-
         val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
         val shouldRunAll = Opts.flag("all", "run all checks").orFalse
         val shouldDeletePubsubTopics =

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
@@ -15,8 +15,8 @@ import java.util.UUID
 
 object Nuker {
   def run[F[_]: Async: Parallel](isDryRun: Boolean,
-                                            shouldRunAll: Boolean,
-                                            shouldDeletePubsubTopics: Boolean
+                                 shouldRunAll: Boolean,
+                                 shouldDeletePubsubTopics: Boolean
   ): Stream[F, Nothing] = {
     implicit def getLogger[F[_]: Sync] = Slf4jLogger.getLogger[F]
     implicit val traceId = Ask.const(TraceId(UUID.randomUUID()))

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
@@ -12,9 +12,9 @@ import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import org.typelevel.log4cats.Logger
 
 class PubsubTopicAndSubscriptionCleaner[F[_]](config: PubsubTopicCleanerConfig,
-                                                     topicAdmin: GoogleTopicAdmin[F],
-                                                     subcriptionAdmin: GoogleSubscriptionAdmin[F],
-                                                     metrics: OpenTelemetryMetrics[F]
+                                              topicAdmin: GoogleTopicAdmin[F],
+                                              subcriptionAdmin: GoogleSubscriptionAdmin[F],
+                                              metrics: OpenTelemetryMetrics[F]
 )(implicit
   F: Async[F],
   logger: Logger[F]
@@ -64,9 +64,9 @@ class PubsubTopicAndSubscriptionCleaner[F[_]](config: PubsubTopicCleanerConfig,
 
 object PubsubTopicAndSubscriptionCleaner {
   def apply[F[_]](config: PubsubTopicCleanerConfig,
-                         topicAdmin: GoogleTopicAdmin[F],
-                         subscriptionAdmin: GoogleSubscriptionAdmin[F],
-                         metrics: OpenTelemetryMetrics[F]
+                  topicAdmin: GoogleTopicAdmin[F],
+                  subscriptionAdmin: GoogleSubscriptionAdmin[F],
+                  metrics: OpenTelemetryMetrics[F]
   )(implicit
     F: Async[F],
     logger: Logger[F]

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/PubsubTopicAndSubscriptionCleaner.scala
@@ -1,29 +1,27 @@
 package com.broadinstitute.dsp
 package nuker
 
-import java.util.concurrent.TimeUnit
-
-import cats.effect.{Concurrent, Timer}
+import cats.effect.Async
 import cats.mtl.Ask
 import com.google.pubsub.v1.{ProjectSubscriptionName, TopicName}
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{GoogleSubscriptionAdmin, GoogleTopicAdmin}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.typelevel.log4cats.Logger
 
-class PubsubTopicAndSubscriptionCleaner[F[_]: Timer](config: PubsubTopicCleanerConfig,
+class PubsubTopicAndSubscriptionCleaner[F[_]](config: PubsubTopicCleanerConfig,
                                                      topicAdmin: GoogleTopicAdmin[F],
                                                      subcriptionAdmin: GoogleSubscriptionAdmin[F],
                                                      metrics: OpenTelemetryMetrics[F]
 )(implicit
-  F: Concurrent[F],
+  F: Async[F],
   logger: Logger[F]
 ) {
   def run(isDryRun: Boolean): F[Unit] = {
     val res = for {
-      now <- Stream.eval(Timer[F].clock.realTime(TimeUnit.MILLISECONDS))
+      now <- Stream.eval(F.realTimeInstant)
       traceId = TraceId(s"pubsubTopicCleaner-${now}")
       implicit0(ev: Ask[F, TraceId]) = Ask.const[F, TraceId](traceId)
       deleteTopicStream = for {
@@ -65,12 +63,12 @@ class PubsubTopicAndSubscriptionCleaner[F[_]: Timer](config: PubsubTopicCleanerC
 }
 
 object PubsubTopicAndSubscriptionCleaner {
-  def apply[F[_]: Timer](config: PubsubTopicCleanerConfig,
+  def apply[F[_]](config: PubsubTopicCleanerConfig,
                          topicAdmin: GoogleTopicAdmin[F],
                          subscriptionAdmin: GoogleSubscriptionAdmin[F],
                          metrics: OpenTelemetryMetrics[F]
   )(implicit
-    F: Concurrent[F],
+    F: Async[F],
     logger: Logger[F]
   ): PubsubTopicAndSubscriptionCleaner[F] =
     new PubsubTopicAndSubscriptionCleaner(config, topicAdmin, subscriptionAdmin, metrics)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,10 +1,9 @@
 import sbt._
 
 object Dependencies {
-  val logbackVersion = "1.2.3"
-  val workbenchGoogle2Version = "0.21-89d0d9e"
-  val doobieVersion = "0.13.4"
-  val openTelemetryVersion = "0.1-52e271f"
+  val workbenchGoogle2Version = "0.23-03a7abb"
+  val doobieVersion = "1.0.0-RC1"
+  val openTelemetryVersion = "0.2-03a7abb"
 
   val core = Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1",
@@ -14,7 +13,7 @@ object Dependencies {
     "org.tpolecat" %% "doobie-hikari" % doobieVersion,
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.17.1",
-    "mysql" % "mysql-connector-java" % "8.0.25",
+    "mysql" % "mysql-connector-java" % "8.0.27",
     "org.scalatest" %% "scalatest" % "3.2.10" % Test,
     "com.monovore" %% "decline" % "2.2.0",
     "dev.optics" %% "monocle-core" % "3.1.0",

--- a/resource-validator/src/main/resources/application.conf.example
+++ b/resource-validator/src/main/resources/application.conf.example
@@ -1,3 +1,0 @@
-leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against
-
-report-destination-bucket = "<YOUR-TESTING-BUCKET>" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket

--- a/resource-validator/src/main/resources/application.conf.example
+++ b/resource-validator/src/main/resources/application.conf.example
@@ -1,0 +1,3 @@
+leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against
+
+report-destination-bucket = "<YOUR-TESTING-BUCKET>" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerChecker.scala
@@ -1,23 +1,16 @@
 package com.broadinstitute.dsp.resourceValidator
 
-import cats.effect.{Concurrent, Timer}
+import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.broadinstitute.dsp.{
-  resourceValidator,
-  CheckRunner,
-  CheckRunnerConfigs,
-  CheckRunnerDeps,
-  RuntimeCheckerDeps,
-  RuntimeWithWorkers
-}
-import org.typelevel.log4cats.Logger
+import com.broadinstitute.dsp._
 import org.broadinstitute.dsde.workbench.google2.DataprocClusterName
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 object DataprocWorkerChecker {
   val unfixableAnomalyCheckType = "unfixable-dataproc-workers"
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, RuntimeWithWorkers] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -24,7 +24,7 @@ object DbReader {
 
   val deletedDisksQuery =
     sql"""
-           SELECT pd1.id, pd1.cloudContext, pd1.name, pd1.zone, pd1.formattedBy
+           SELECT pd1.id, pd1.cloudContext, pd1.cloudProvider, pd1.name, pd1.zone, pd1.formattedBy
            FROM PERSISTENT_DISK AS pd1
            WHERE pd1.status="Deleted" AND
            pd1.destroyedDate > now() - INTERVAL 30 DAY AND
@@ -41,7 +41,7 @@ object DbReader {
       .query[InitBucketToRemove]
 
   val deletedRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, cloudContext, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
+    sql"""SELECT DISTINCT c1.id, cloudContext, c1.cloudProvider, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
@@ -58,7 +58,7 @@ object DbReader {
       .query[Runtime]
 
   val erroredRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, cloudContext, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
+    sql"""SELECT DISTINCT c1.id, cloudContext, cloudProvider, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
@@ -74,7 +74,7 @@ object DbReader {
       .query[Runtime]
 
   val stoppedRuntimeQuery =
-    sql"""SELECT DISTINCT c1.id, c1.cloudContext, c1.runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
+    sql"""SELECT DISTINCT c1.id, c1.cloudContext, c1.cloudProvider, c1.runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -1,11 +1,11 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.{Async, _}
+import cats.effect.Async
+import com.broadinstitute.dsp.DbReaderImplicits._
 import doobie._
 import doobie.implicits._
 import fs2.Stream
-import DbReaderImplicits._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
 trait DbReader[F[_]] {
@@ -116,7 +116,7 @@ object DbReader {
          """
       .query[RuntimeWithWorkers]
 
-  def impl[F[_]: ContextShift](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
+  def impl[F[_]](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
 
     /**
      * AOU reuses runtime names, hence exclude any aou runtimes that have the same names that're still "alive"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -28,7 +28,7 @@ object DeletedDiskChecker {
         for {
           googleProject <- disk.cloudContext match {
             case CloudContext.Azure(_) => F.raiseError(new NotImplementedError())
-            case CloudContext.Gcp(p) => F.pure(p)
+            case CloudContext.Gcp(p)   => F.pure(p)
           }
           diskOpt <- deps.googleDiskService.getDisk(googleProject, disk.zone, disk.diskName)
           _ <-

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -5,6 +5,7 @@ import cats.Parallel
 import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
+import kotlin.NotImplementedError
 import org.broadinstitute.dsde.workbench.google2.DiskName
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
@@ -25,7 +26,11 @@ object DeletedDiskChecker {
         ev: Ask[F, TraceId]
       ): F[Option[Disk]] =
         for {
-          diskOpt <- deps.googleDiskService.getDisk(disk.googleProject, disk.zone, disk.diskName)
+          googleProject <- disk.cloudContext match {
+            case CloudContext.Azure(_) => F.raiseError(new NotImplementedError())
+            case CloudContext.Gcp(p) => F.pure(p)
+          }
+          diskOpt <- deps.googleDiskService.getDisk(googleProject, disk.zone, disk.diskName)
           _ <-
             if (!isDryRun) {
               if (disk.formattedBy.getOrElse(None) == "GALAXY") {
@@ -33,11 +38,11 @@ object DeletedDiskChecker {
                 val postgresDiskName = DiskName(s"${dataDiskName.value}-gxy-postres-disk")
                 diskOpt.traverse { _ =>
                   List(postgresDiskName, dataDiskName).parTraverse(dn =>
-                    deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, dn)
+                    deps.googleDiskService.deleteDisk(googleProject, disk.zone, dn)
                   )
                 }
               } else
-                diskOpt.traverse(_ => deps.googleDiskService.deleteDisk(disk.googleProject, disk.zone, disk.diskName))
+                diskOpt.traverse(_ => deps.googleDiskService.deleteDisk(googleProject, disk.zone, disk.diskName))
             } else F.pure(None)
         } yield diskOpt.map(_ => disk)
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskChecker.scala
@@ -2,16 +2,16 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.Parallel
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.DiskName
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object DeletedDiskChecker {
-  def impl[F[_]: Timer: Parallel](
+  def impl[F[_]: Parallel](
     dbReader: DbReader[F],
     deps: DiskCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Disk] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
@@ -1,15 +1,15 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import org.typelevel.log4cats.Logger
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 object DeletedOrErroredKubernetesClusterChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: KubernetesClusterCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, KubernetesCluster] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -1,16 +1,16 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import org.typelevel.log4cats.Logger
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object DeletedRuntimeChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeChecker.scala
@@ -1,16 +1,16 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import org.typelevel.log4cats.Logger
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object ErroredRuntimeChecker {
-  def iml[F[_]: Timer](
+  def iml[F[_]](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/InitBucketChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/InitBucketChecker.scala
@@ -1,19 +1,18 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import org.typelevel.log4cats.Logger
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 object InitBucketChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: CheckRunnerDeps[F]
   )(implicit
     F: Concurrent[F],
-    timer: Timer[F],
     logger: Logger[F],
     ev: Ask[F, TraceId]
   ): CheckRunner[F, InitBucketToRemove] =

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
@@ -4,8 +4,7 @@ package resourceValidator
 import cats.effect.IO
 import cats.syntax.all._
 import com.monovore.decline.{CommandApp, _}
-
-import scala.concurrent.ExecutionContext.global
+import cats.effect.unsafe.implicits.global
 
 object Main
     extends CommandApp(
@@ -13,9 +12,6 @@ object Main
       header = "Update Google resources to reflect Leonardo database",
       version = "0.0.1",
       main = {
-        implicit val cs = IO.contextShift(global)
-        implicit val timer = IO.timer(global)
-
         val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
         val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
         val shouldCheckDeletedRuntimes = Opts.flag("checkDeletedRuntimes", "check all deleted runtimes").orFalse

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.Parallel
-import cats.effect.{Concurrent, Timer}
+import cats.effect.{Concurrent}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
@@ -14,7 +14,7 @@ import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object StoppedRuntimeChecker {
-  def iml[F[_]: Timer: Parallel](
+  def iml[F[_]:  Parallel](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =
@@ -84,7 +84,7 @@ object StoppedRuntimeChecker {
                       ) >> deps.dataprocService
                         // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
                         // in order to keep things simple since our main goal here is to prevent unintended cost to users.
-                        .stopCluster(project, runtime.region, clusterName, metadata = None)
+                        .stopCluster(project, runtime.region, clusterName, metadata = None, true)
                         .void
                         .as(runtime.some)
                   } else F.pure(none[Runtime.Dataproc])

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -2,14 +2,11 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.Parallel
-import cats.effect.{Concurrent}
+import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
-import com.google.cloud.compute.v1.Instance
-import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -5,13 +5,15 @@ import cats.Parallel
 import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
+import com.google.cloud.compute.v1.Instance
+import com.google.cloud.dataproc.v1.ClusterStatus
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
 object StoppedRuntimeChecker {
-  def iml[F[_]:  Parallel](
+  def iml[F[_]: Parallel](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =
@@ -38,7 +40,7 @@ object StoppedRuntimeChecker {
           runtimeOpt <- deps.computeService
             .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
           runningRuntimeOpt <- runtimeOpt.flatTraverse { rt =>
-            if (rt.getStatus == "RUNNING")
+            if (rt.getStatus == Instance.Status.RUNNING)
               if (isDryRun)
                 logger.warn(s"${runtime} is running. It needs to be stopped.").as[Option[Runtime]](Some(runtime))
               else
@@ -63,22 +65,22 @@ object StoppedRuntimeChecker {
           clusterOpt <- deps.dataprocService
             .getCluster(runtime.googleProject, runtime.region, DataprocClusterName(runtime.runtimeName))
           runningClusterOpt <- clusterOpt.flatTraverse { cluster =>
-            if (cluster.getStatus.getState.name.toUpperCase == "RUNNING") {
+            if (cluster.getStatus.getState == ClusterStatus.State.RUNNING) {
               for {
                 rt <-
-                    if (isDryRun)
-                      logger
-                        .warn(s"Cluster (${runtime}) has running instance(s). It needs to be stopped.")
-                        .as(runtime.some)
-                    else
-                      logger.warn(
-                        s"Cluster (${runtime}) has running instances(s). Going to stop it."
-                      ) >> deps.dataprocService
-                        // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
-                        // in order to keep things simple since our main goal here is to prevent unintended cost to users.
-                        .stopCluster(project, runtime.region, clusterName, metadata = None, true)
-                        .void
-                        .as(runtime.some)
+                  if (isDryRun)
+                    logger
+                      .warn(s"Dry run: Cluster (${runtime}) is Running It needs to be stopped.")
+                      .as(runtime.some)
+                  else
+                    logger.warn(
+                      s"Cluster (${runtime}) has running instances(s). Going to stop it."
+                    ) >> deps.dataprocService
+                      // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
+                      // in order to keep things simple since our main goal here is to prevent unintended cost to users.
+                      .stopCluster(project, runtime.region, clusterName, metadata = None, true)
+                      .void
+                      .as(runtime.some)
               } yield rt
             } else F.pure(none[Runtime.Dataproc])
           }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DataprocWorkerCheckerSpec.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import com.broadinstitute.dsp.Generators._
-
+import cats.effect.unsafe.implicits.global
 class DataprocWorkerCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
   // we don't want to duplicate the purpose of the deleted runtime checker here

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -7,7 +7,7 @@ import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -13,7 +13,7 @@ import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskCheckerSpec.scala
@@ -7,13 +7,13 @@ import com.broadinstitute.dsp.Generators._
 import com.google.cloud.compute.v1
 import com.google.cloud.compute.v1.Operation
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
-import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService, MockGoogleDiskService, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleStorageInterpreter, MockGoogleDiskService}
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
-
+import cats.effect.unsafe.implicits.global
 class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if disk no longer exists in Google" in {
     val diskService = new MockGoogleDiskService {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.mock.MockGKEService
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.scalatest.flatspec.AnyFlatSpec
+import cats.effect.unsafe.implicits.global
 
 class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if kubernetes cluster no longer exists in Google" in {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, Mock
 import org.broadinstitute.dsde.workbench.model.TraceId
 import com.google.container.v1.NodePool
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
   it should "not publish to subscriber if dryRun" in {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.workbench.google2.{
 }
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -20,7 +20,7 @@ import org.broadinstitute.dsde.workbench.google2.{
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
-
+import cats.effect.unsafe.implicits.global
 class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if runtime no longer exists in Google" in {
     val computeService = new FakeGoogleComputeService {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitBucketCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitBucketCheckerSpec.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProj
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import cats.effect.unsafe.implicits.global
 
 class InitBucketCheckerSpec extends AnyFlatSpec with CronJobsTestSuite with MockitoSugar {
   val mockBucket = mock[Bucket]

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
@@ -1,9 +1,9 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.implicits._
 import cats.effect.IO
 import cats.mtl.Ask
-import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper._
 import com.google.cloud.compute.v1.{Instance, Operation}
 import com.google.cloud.dataproc.v1.ClusterStatus.State
@@ -17,6 +17,8 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import com.broadinstitute.dsp.resourceValidator.StoppedRuntimeCheckerSpec._
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
+import com.broadinstitute.dsp.Generators.genRuntime
+import org.scalacheck.Arbitrary
 
 final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if runtime no longer exists in Google" in {
@@ -34,6 +36,7 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
     val runtimeCheckerDeps =
       initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
 
+    import com.broadinstitute.dsp.Generators.arbRuntime
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getStoppedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
@@ -45,6 +48,8 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
   }
 
   it should "return Runtime if it is RUNNING in Google" in {
+    implicit val arbA = Arbitrary(genRuntime(List("Stopped").toNel))
+
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getStoppedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
@@ -89,50 +94,6 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
 
       res.unsafeRunSync() shouldBe expectedRes
 
-    }
-  }
-
-  it should "return None if Dataproc cluster is RUNNING but its instances are STOPPED" in {
-    implicit val arbA = arbDataprocRuntime
-    forAll { (runtime: Runtime.Dataproc, dryRun: Boolean) =>
-      val dbReader = new FakeDbReader {
-        override def getStoppedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
-      }
-
-      val computeService = new FakeGoogleComputeService {
-        override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
-          ev: Ask[IO, TraceId]
-        ): IO[Option[Instance]] = {
-          val instance = Instance.newBuilder().setStatus(Instance.Status.STOPPED).build()
-          IO.pure(Some(instance))
-        }
-
-        override def stopInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
-          ev: Ask[IO, TraceId]
-        ): IO[Operation] = if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(defaultOperation)
-      }
-
-      val dataprocService = new BaseFakeGoogleDataprocService {
-        override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
-          ev: Ask[IO, TraceId]
-        ): IO[Option[Cluster]] =
-          IO.pure(Some(makeClusterWithStatus("RUNNING")))
-
-        override def getClusterInstances(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
-          implicit ev: Ask[IO, TraceId]
-        ) =
-          IO.pure(dataprocRoleZonePreemptibilityInstances)
-
-        override def stopCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName, metadata: Option[Map[String, String]], isFullStop: Boolean)(implicit ev: Ask[IO, TraceId]): IO[Option[DataprocOperation]] =
-          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(Some(defaultDataprocOperation))
-      }
-
-      val runtimeCheckerDeps =
-        initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
-
-      val stoppedRuntimeChecker = StoppedRuntimeChecker.iml(dbReader, runtimeCheckerDeps)
-      val res = stoppedRuntimeChecker.checkResource(runtime, dryRun)
-      res.unsafeRunSync() shouldBe None
     }
   }
 }

--- a/zombie-monitor/src/main/resources/reference.conf
+++ b/zombie-monitor/src/main/resources/reference.conf
@@ -6,10 +6,11 @@ database {
   password = ${LEONARDO_DB_PASSWORD}
 }
 
-report-destination-bucket = "replace-me"
+report-destination-bucket = "qitest"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 }
 
+leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against

--- a/zombie-monitor/src/main/resources/reference.conf
+++ b/zombie-monitor/src/main/resources/reference.conf
@@ -6,11 +6,10 @@ database {
   password = ${LEONARDO_DB_PASSWORD}
 }
 
-report-destination-bucket = "qitest"
+report-destination-bucket = "replace-me"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 }
 
-leonardo-pubsub.google-project = "broad-dsde-dev" # or project you want to test against

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -61,7 +61,7 @@ object DbReader {
           UPDATE NODEPOOL
           INNER JOIN KUBERNETES_CLUSTER ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId
           LEFT JOIN APP ON APP.nodepoolId = NODEPOOL.id
-          SET diskId = NULL, KUBERNETES_CLUSTER.status = "DELETED", KUBERNETES_CLUSTER.destroyedDate = now()
+          SET diskId = NULL, KUBERNETES_CLUSTER.status = "DELETED", KUBERNETES_CLUSTER.destroyedDate = now(), NODEPOOL.status = "DELETED", NODEPOOL.destroyedDate=now()
           where KUBERNETES_CLUSTER.id = $id""".update
 
   def markNodepoolDeletedQuery(id: Long) =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -1,12 +1,12 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.effect.{Async, _}
-import fs2.Stream
-import DbReaderImplicits._
+import cats.effect.Async
+import cats.syntax.all._
+import com.broadinstitute.dsp.DbReaderImplicits._
 import doobie._
 import doobie.implicits._
-import cats.syntax.all._
+import fs2.Stream
 
 trait DbReader[F[_]] {
   def getDisksToDeleteCandidate: Stream[F, Disk]
@@ -109,7 +109,7 @@ object DbReader {
       update CLUSTER set deletedFrom = $deletedFrom where id = $runtimeId
       """.update
 
-  def impl[F[_]: ContextShift](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
+  def impl[F[_]](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
     override def getRuntimeCandidate: Stream[F, Runtime] = activeRuntimeQuery.stream.transact(xa)
 
     override def getDisksToDeleteCandidate: Stream[F, Disk] =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -28,13 +28,13 @@ object DbReader {
   implicit def apply[F[_]](implicit ev: DbReader[F]): DbReader[F] = ev
 
   val activeDisksQuery =
-    sql"""select id, cloudContext, name, zone, formattedBy from PERSISTENT_DISK where status != "Deleted" and status != "Error";
+    sql"""select id, cloudContext, cloudProvider, name, zone, formattedBy from PERSISTENT_DISK where status != "Deleted" and status != "Error";
         """.query[Disk]
 
   // We only check runtimes that have been created for more than 1 hour because a newly "Creating" runtime may not exist in Google yet
   val activeRuntimeQuery =
     sql"""
-         SELECT DISTINCT c1.id, cloudContext, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
+         SELECT DISTINCT c1.id, cloudContext, cloudProvider, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
             FROM CLUSTER AS c1
             INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
             WHERE c1.status!="Deleted" AND c1.status!="Error" AND createdDate < now() - INTERVAL 1 HOUR

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -60,9 +60,9 @@ object DbReader {
     sql"""
           UPDATE NODEPOOL
           INNER JOIN KUBERNETES_CLUSTER ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId
-          INNER JOIN APP ON APP.nodepoolId = NODEPOOL.id
+          LEFT JOIN APP ON APP.nodepoolId = NODEPOOL.id
           SET diskId = NULL, KUBERNETES_CLUSTER.status = "DELETED", KUBERNETES_CLUSTER.destroyedDate = now()
-          where KUBERNETES_CLUSTER.id = $id           """.update
+          where KUBERNETES_CLUSTER.id = $id""".update
 
   def markNodepoolDeletedQuery(id: Long) =
     sql"""

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -58,8 +58,8 @@ object DbReader {
 
   def markK8sClusterDeletedQuery(id: Int) =
     sql"""
-          UPDATE NODEPOOL
-          INNER JOIN KUBERNETES_CLUSTER ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId
+          UPDATE KUBERNETES_CLUSTER
+          LEFT JOIN NODEPOOL ON KUBERNETES_CLUSTER.id = NODEPOOL.clusterId
           LEFT JOIN APP ON APP.nodepoolId = NODEPOOL.id
           SET diskId = NULL, KUBERNETES_CLUSTER.status = "DELETED", KUBERNETES_CLUSTER.destroyedDate = now(), NODEPOOL.status = "DELETED", NODEPOOL.destroyedDate=now()
           where KUBERNETES_CLUSTER.id = $id""".update

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -1,19 +1,19 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
+import cats.syntax.all._
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 /**
  * Similar to `DeletedDiskChecker` in `resource-validator`, but this process all disks and check if they still exists in google.
  * If not, we update leonardo DB to reflect that they're deleted
  */
 object DeletedDiskChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: DiskCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Disk] =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -29,7 +29,7 @@ object DeletedDiskChecker {
         for {
           googleProject <- disk.cloudContext match {
             case CloudContext.Azure(_) => F.raiseError(new NotImplementedError())
-            case CloudContext.Gcp(p) => F.pure(p)
+            case CloudContext.Gcp(p)   => F.pure(p)
           }
           diskOpt <- deps.googleDiskService.getDisk(googleProject, disk.zone, disk.diskName)
           _ <-

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -35,7 +35,8 @@ object DeletedKubernetesClusterChecker {
             if (isDryRun) F.unit
             else
               clusterOpt match {
-                case None    => dbReader.markK8sClusterDeleted(cluster.id)
+                case None =>
+                  logger.info(s"Going to mark k8s ${cluster} as DELETED") >> dbReader.markK8sClusterDeleted(cluster.id)
                 case Some(_) => F.unit
               }
         } yield clusterOpt.fold[Option[K8sClusterToScan]](Some(cluster))(_ => none[K8sClusterToScan])

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -1,19 +1,19 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.effect.{Concurrent, Timer}
+import cats.effect.Concurrent
 import cats.mtl.Ask
-import fs2.Stream
-import org.typelevel.log4cats.Logger
-import org.broadinstitute.dsde.workbench.model.TraceId
 import cats.syntax.all._
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 /**
  * Similar to `DeletedDiskChecker`, but this process all non deleted k8s clusters and check if they still exists in google.
  * If not, we update leonardo DB to reflect that they're deleted
  */
 object DeletedKubernetesClusterChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: KubernetesClusterCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, K8sClusterToScan] =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
@@ -1,12 +1,12 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
+import cats.syntax.all._
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 /**
  * Scans through all active nodepools, and update DB accordingly when necessary
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
  * - if nodepool exist in non ERROR state, do nothing and don't report the nodepool
  */
 object DeletedOrErroredNodepoolChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: KubernetesClusterCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, NodepoolToScan] =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeChecker.scala
@@ -1,13 +1,13 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.effect.{Concurrent, Timer}
-import cats.syntax.all._
+import cats.effect.Concurrent
 import cats.mtl.Ask
+import cats.syntax.all._
 import fs2.Stream
-import org.typelevel.log4cats.Logger
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
 
 /**
  * Take a `Stream` of active runtimes, and check their status in google
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
  * 3. else, do nothing
  */
 object DeletedOrErroredRuntimeChecker {
-  def impl[F[_]: Timer](
+  def impl[F[_]](
     dbReader: DbReader[F],
     deps: RuntimeCheckerDeps[F]
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Runtime] =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
@@ -1,9 +1,9 @@
 package com.broadinstitute.dsp.zombieMonitor
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.all._
 import com.monovore.decline.{CommandApp, _}
-import scala.concurrent.ExecutionContext.global
 
 object Main
     extends CommandApp(
@@ -11,9 +11,6 @@ object Main
       header = "Update Leonardo database to reflect google resource status",
       version = "0.0.1",
       main = {
-        implicit val cs = IO.contextShift(global)
-        implicit val timer = IO.timer(global)
-
         val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
         val shouldRunAll = Opts.flag("all", "run all checks").orFalse
         val shouldCheckDeletedOrErrorRuntimes =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -36,7 +36,7 @@ object ZombieMonitor {
     for {
       config <- Stream.fromEither(Config.appConfig)
       deps <- Stream.resource(initDependencies(config))
-
+      _ <- if(isDryRun) Stream.eval(getLogger.info("Running in dry run mode")) else Stream.eval(getLogger.info("Running in non dry run mode"))
       deleteDiskCheckerProcess =
         if (shouldRunAll || shouldCheckDeletedDisks)
           Stream.eval(DeletedDiskChecker.impl(deps.dbReader, deps.diskCheckerDeps).run(isDryRun))

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -36,7 +36,9 @@ object ZombieMonitor {
     for {
       config <- Stream.fromEither(Config.appConfig)
       deps <- Stream.resource(initDependencies(config))
-      _ <- if(isDryRun) Stream.eval(getLogger.info("Running in dry run mode")) else Stream.eval(getLogger.info("Running in non dry run mode"))
+      _ <-
+        if (isDryRun) Stream.eval(getLogger.info("Running in dry run mode"))
+        else Stream.eval(getLogger.info("Running in non dry run mode"))
       deleteDiskCheckerProcess =
         if (shouldRunAll || shouldCheckDeletedDisks)
           Stream.eval(DeletedDiskChecker.impl(deps.dbReader, deps.diskCheckerDeps).run(isDryRun))

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -43,7 +43,7 @@ object ZombieMonitor {
         else Stream.empty
       deleteRuntimeCheckerProcess =
         if (shouldRunAll || shouldCheckDeletedRuntimes)
-          Stream.eval(DeletedOrErroredRuntimeChecker.impl(deps.dbReader, deps.runtimeCheckerDeps).run(isDryRun))
+          Stream.eval(ActiveRuntimeChecker.impl(deps.dbReader, deps.runtimeCheckerDeps).run(isDryRun))
         else Stream.empty
       deletek8sClusterCheckerProcess =
         if (shouldRunAll || shouldCheckDeletedK8sClusters)

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -37,8 +37,8 @@ object ZombieMonitor {
       config <- Stream.fromEither(Config.appConfig)
       deps <- Stream.resource(initDependencies(config))
       _ <-
-        if (isDryRun) Stream.eval(getLogger.info("Running in dry run mode"))
-        else Stream.eval(getLogger.info("Running in non dry run mode"))
+        if (isDryRun) Stream.eval(logger.info("Running in dry run mode"))
+        else Stream.eval(logger.info("Running in non dry run mode"))
       deleteDiskCheckerProcess =
         if (shouldRunAll || shouldCheckDeletedDisks)
           Stream.eval(DeletedDiskChecker.impl(deps.dbReader, deps.diskCheckerDeps).run(isDryRun))

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -1,38 +1,27 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
+import cats.implicits._
 import cats.effect.IO
 import cats.mtl.Ask
-import com.broadinstitute.dsp.Generators._
 import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.{
-  BaseFakeGoogleDataprocService,
-  FakeGoogleBillingInterpreter,
-  FakeGoogleComputeService,
-  FakeGoogleDataprocService,
-  FakeGoogleStorageInterpreter
-}
-import org.broadinstitute.dsde.workbench.google2.{
-  DataprocClusterName,
-  GoogleBillingService,
-  GoogleComputeService,
-  GoogleDataprocService,
-  GoogleStorageService,
-  InstanceName,
-  RegionName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleBillingInterpreter, FakeGoogleComputeService, FakeGoogleDataprocService, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, GoogleBillingService, GoogleComputeService, GoogleDataprocService, GoogleStorageService, InstanceName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import cats.effect.unsafe.implicits.global
+import com.broadinstitute.dsp.Generators.{arbDataprocRuntime, genRuntime}
+import org.scalacheck.Arbitrary
 
 class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "report a runtime if it doesn't exist in google but is still active in leonardo DB" in {
+    implicit val arbA = Arbitrary(genRuntime(List("Running", "Creating").toNel))
+
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getRuntimeCandidate: Stream[IO, Runtime] =
@@ -62,6 +51,7 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   }
 
   it should "report a runtime if it's Stopped in google but is still active in leonardo DB" in {
+    import com.broadinstitute.dsp.Generators.arbRuntime
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getRuntimeCandidate: Stream[IO, Runtime] =
@@ -86,7 +76,7 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       val computeService = new FakeGoogleComputeService {
         override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
                                                                                                      ev: Ask[IO, TraceId]
-        ): IO[Option[Instance]] = IO.pure(Some(Instance.newBuilder().setStatus(Instance.Status.STOPPED).build()))
+        ): IO[Option[Instance]] = IO.pure(Some(Instance.newBuilder().setStatus(Instance.Status.TERMINATED).build()))
       }
       val deps = initRuntimeCheckerDeps(computeService, dataprocService)
       val checker = ActiveRuntimeChecker.impl(dbReader, deps)
@@ -96,6 +86,8 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   }
 
   it should "not a report runtime if it still exists in google and is active in leonardo DB" in {
+    import com.broadinstitute.dsp.Generators.arbRuntime
+
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getRuntimeCandidate: Stream[IO, Runtime] =

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.util.{Calendar, GregorianCalendar}
+
 /**
  * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
  * For running these tests locally, you can

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleStorageInterpre
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import cats.effect.unsafe.implicits.global
 
 class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "report nodepool if it doesn't exist in google but still active in leonardo DB" in {

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredRuntimeCheckerSpec.scala
@@ -29,6 +29,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import cats.effect.unsafe.implicits.global
 
 class DeletedOrErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "report a runtime if it doesn't exist in google but is still active in leonardo DB" in {
@@ -71,7 +72,7 @@ class DeletedOrErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSu
       val computeService = new FakeGoogleComputeService {
         override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
           ev: Ask[IO, TraceId]
-        ): IO[Option[Instance]] = IO.pure(Some(Instance.newBuilder().setStatus("Running").build()))
+        ): IO[Option[Instance]] = IO.pure(Some(Instance.newBuilder().setStatus(Instance.Status.RUNNING).build()))
       }
       val dataprocService = new BaseFakeGoogleDataprocService {
         override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3005

1. Update resource validator to use the new dataproc cluster client so that it'll fully stop clusters.. See `StoppedRuntimeChecker`
2. Update zombie monitor in a way that if it detects an active runtime (active in leo DB) is `Stopped` in google, it'll update DB to reflect it...See `ActiveRuntimeChecker`. 
3. Fix a bug in `markK8sClusterDeletedQuery` query. We can't `INNER JOIN` nodepool table and App table because not all nodepools have an App. We can't `INNER JOIN` kubernetes cluster table and nodepool table either because not all cluster id has a corresponding nodepool.

Majority of the diff is due to cats-effect 3 migration, and some leftover refactoring needed due to azure refactoring..


Tested all runners locally against dev