### PR TITLE
IA-3005 fix shutdown issue

### DIFF
--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
@@ -1,49 +1,50 @@
 package com.broadinstitute.dsp
 package janitor
 
-import cats.effect.IO
+import cats.effect.{ExitCode, IO}
 import cats.syntax.all._
 import com.monovore.decline._
-import cats.effect.unsafe.implicits.global
+import com.monovore.decline.effect.CommandIOApp
+
 object Main
-    extends CommandApp(
-      name = "janitor",
-      header = "Clean up prod resources deemed not utilized",
-      version = "0.0.1",
-      main = {
-        val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
-        val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
+    extends CommandIOApp(name = "janitor",
+                         header = "Clean up prod resources deemed not utilized",
+                         version = "2022.1.5"
+    ) {
+  override def main: Opts[IO[ExitCode]] = {
+    val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
+    val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
 
-        val shouldCheckKubernetesClustersToBeRemoved =
-          Opts.flag("checkKubernetesClustersToRemove", "check kubernetes clusters that should be removed").orFalse
-        val shouldCheckNodepoolsToBeRemoved =
-          Opts.flag("checkNodepoolsToRemove", "check nodepools that should be removed").orFalse
-        val shouldCheckStagingBucketsToBeRemoved =
-          Opts.flag("checkStagingBucketsToRemove", "check staging buckets that should be removed").orFalse
+    val shouldCheckKubernetesClustersToBeRemoved =
+      Opts.flag("checkKubernetesClustersToRemove", "check kubernetes clusters that should be removed").orFalse
+    val shouldCheckNodepoolsToBeRemoved =
+      Opts.flag("checkNodepoolsToRemove", "check nodepools that should be removed").orFalse
+    val shouldCheckStagingBucketsToBeRemoved =
+      Opts.flag("checkStagingBucketsToRemove", "check staging buckets that should be removed").orFalse
 
-        (enableDryRun,
-         shouldCheckAll,
-         shouldCheckKubernetesClustersToBeRemoved,
-         shouldCheckNodepoolsToBeRemoved,
-         shouldCheckStagingBucketsToBeRemoved
-        ).mapN {
-          (dryRun,
-           checkAll,
-           shouldCheckKubernetesClustersToBeRemoved,
-           shouldCheckNodepoolsToBeRemoved,
-           shouldCheckStagingBucketsToBeRemoved
-          ) =>
-            Janitor
-              .run[IO](
-                isDryRun = dryRun,
-                shouldCheckAll = checkAll,
-                shouldCheckKubernetesClustersToBeRemoved = shouldCheckKubernetesClustersToBeRemoved,
-                shouldCheckNodepoolsToBeRemoved = shouldCheckNodepoolsToBeRemoved,
-                shouldCheckStagingBucketsToBeRemoved = shouldCheckStagingBucketsToBeRemoved
-              )
-              .compile
-              .drain
-              .unsafeRunSync()
-        }
-      }
-    )
+    (enableDryRun,
+     shouldCheckAll,
+     shouldCheckKubernetesClustersToBeRemoved,
+     shouldCheckNodepoolsToBeRemoved,
+     shouldCheckStagingBucketsToBeRemoved
+    ).mapN {
+      (dryRun,
+       checkAll,
+       shouldCheckKubernetesClustersToBeRemoved,
+       shouldCheckNodepoolsToBeRemoved,
+       shouldCheckStagingBucketsToBeRemoved
+      ) =>
+        Janitor
+          .run[IO](
+            isDryRun = dryRun,
+            shouldCheckAll = checkAll,
+            shouldCheckKubernetesClustersToBeRemoved = shouldCheckKubernetesClustersToBeRemoved,
+            shouldCheckNodepoolsToBeRemoved = shouldCheckNodepoolsToBeRemoved,
+            shouldCheckStagingBucketsToBeRemoved = shouldCheckStagingBucketsToBeRemoved
+          )
+          .compile
+          .drain
+          .as(ExitCode.Success)
+    }
+  }
+}

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Main.scala
@@ -1,28 +1,28 @@
 package com.broadinstitute.dsp
 package nuker
 
-import cats.effect.IO
+import cats.effect.{ExitCode, IO}
 import cats.syntax.all._
 import com.monovore.decline._
-import cats.effect.unsafe.implicits.global
+import com.monovore.decline.effect.CommandIOApp
 
 object Main
-    extends CommandApp(
-      name = "nuker",
-      header = "Clean up cloud resources created by Leonardo in dev/qa projects",
-      version = "0.0.1",
-      main = {
-        val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
-        val shouldRunAll = Opts.flag("all", "run all checks").orFalse
-        val shouldDeletePubsubTopics =
-          Opts.flag("deletePubsubTopics", "delete all fiab pubsub topics").orFalse
+    extends CommandIOApp(name = "nuker",
+                         header = "Clean up cloud resources created by Leonardo in dev/qa projects",
+                         version = "2022.1.5"
+    ) {
+  override def main: Opts[IO[ExitCode]] = {
+    val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
+    val shouldRunAll = Opts.flag("all", "run all checks").orFalse
+    val shouldDeletePubsubTopics =
+      Opts.flag("deletePubsubTopics", "delete all fiab pubsub topics").orFalse
 
-        (enableDryRun, shouldRunAll, shouldDeletePubsubTopics).mapN { (dryRun, runAll, deletePubsubTopics) =>
-          Nuker
-            .run[IO](dryRun, runAll, deletePubsubTopics)
-            .compile
-            .drain
-            .unsafeRunSync()
-        }
-      }
-    )
+    (enableDryRun, shouldRunAll, shouldDeletePubsubTopics).mapN { (dryRun, runAll, deletePubsubTopics) =>
+      Nuker
+        .run[IO](dryRun, runAll, deletePubsubTopics)
+        .compile
+        .drain
+        .as(ExitCode.Success)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,10 @@
 import sbt._
 
 object Dependencies {
-  val workbenchGoogle2Version = "0.23-03a7abb"
+  val workbenchGoogle2Version = "0.23-919aaa00-SNAP"
   val doobieVersion = "1.0.0-RC1"
   val openTelemetryVersion = "0.2-03a7abb"
+  val declineVersion = "2.2.0"
 
   val core = Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1",
@@ -15,7 +16,8 @@ object Dependencies {
     "com.github.pureconfig" %% "pureconfig" % "0.17.1",
     "mysql" % "mysql-connector-java" % "8.0.27",
     "org.scalatest" %% "scalatest" % "3.2.10" % Test,
-    "com.monovore" %% "decline" % "2.2.0",
+    "com.monovore" %% "decline" % declineVersion,
+    "com.monovore" %% "decline-effect" % declineVersion,
     "dev.optics" %% "monocle-core" % "3.1.0",
     "dev.optics" %% "monocle-macro" % "3.1.0",
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val workbenchGoogle2Version = "0.23-919aaa00-SNAP"
+  val workbenchGoogle2Version = "0.23-fdc25f3"
   val doobieVersion = "1.0.0-RC1"
   val openTelemetryVersion = "0.2-03a7abb"
   val declineVersion = "2.2.0"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Main.scala
@@ -1,70 +1,70 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import cats.effect.IO
+import cats.effect.{ExitCode, IO}
 import cats.syntax.all._
-import com.monovore.decline.{CommandApp, _}
-import cats.effect.unsafe.implicits.global
+import com.monovore.decline.effect.CommandIOApp
+import com.monovore.decline._
 
 object Main
-    extends CommandApp(
-      name = "resource-validator",
-      header = "Update Google resources to reflect Leonardo database",
-      version = "0.0.1",
-      main = {
-        val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
-        val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
-        val shouldCheckDeletedRuntimes = Opts.flag("checkDeletedRuntimes", "check all deleted runtimes").orFalse
-        val shouldCheckErroredRuntimes = Opts.flag("checkErroredRuntimes", "check all errored runtimes").orFalse
-        val shouldCheckStoppedRuntimes = Opts.flag("checkStoppedRuntimes", "check all stopped runtimes").orFalse
-        val shouldCheckDeletedKubernetesClusters =
-          Opts.flag("checkDeletedKubernetesClusters", "check all deleted or errored kubernetes clusters").orFalse
-        val shouldCheckDeletedNodepools =
-          Opts.flag("checkDeletedNodepools", "check all deleted or errored nodepools").orFalse
-        val shouldCheckDeletedDisks = Opts.flag("checkDeletedDisks", "check all deleted disks").orFalse
-        val shouldCheckInitBuckets =
-          Opts.flag("checkInitBuckets", "checks that init buckets for deleted runtimes are deleted").orFalse
-        val shouldCheckDataprocWorkers =
-          Opts.flag("checkDataprocWorkers", "check dataproc workers").orFalse
+    extends CommandIOApp(name = "resource-validator",
+                         header = "Update Google resources to reflect Leonardo database",
+                         version = "2022.1.5"
+    ) {
+  override def main: Opts[IO[ExitCode]] = {
+    val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
+    val shouldCheckAll = Opts.flag("all", "run all checks").orFalse
+    val shouldCheckDeletedRuntimes = Opts.flag("checkDeletedRuntimes", "check all deleted runtimes").orFalse
+    val shouldCheckErroredRuntimes = Opts.flag("checkErroredRuntimes", "check all errored runtimes").orFalse
+    val shouldCheckStoppedRuntimes = Opts.flag("checkStoppedRuntimes", "check all stopped runtimes").orFalse
+    val shouldCheckDeletedKubernetesClusters =
+      Opts.flag("checkDeletedKubernetesClusters", "check all deleted or errored kubernetes clusters").orFalse
+    val shouldCheckDeletedNodepools =
+      Opts.flag("checkDeletedNodepools", "check all deleted or errored nodepools").orFalse
+    val shouldCheckDeletedDisks = Opts.flag("checkDeletedDisks", "check all deleted disks").orFalse
+    val shouldCheckInitBuckets =
+      Opts.flag("checkInitBuckets", "checks that init buckets for deleted runtimes are deleted").orFalse
+    val shouldCheckDataprocWorkers =
+      Opts.flag("checkDataprocWorkers", "check dataproc workers").orFalse
 
-        (enableDryRun,
-         shouldCheckAll,
-         shouldCheckDeletedRuntimes,
-         shouldCheckErroredRuntimes,
-         shouldCheckStoppedRuntimes,
-         shouldCheckDeletedKubernetesClusters,
-         shouldCheckDeletedNodepools,
-         shouldCheckDeletedDisks,
-         shouldCheckInitBuckets,
-         shouldCheckDataprocWorkers
-        ).mapN {
-          (dryRun,
-           checkAll,
-           shouldCheckDeletedRuntimes,
-           shouldCheckErroredRuntimes,
-           shouldCheckStoppedRuntimes,
-           shouldCheckDeletedKubernetesClusters,
-           shouldCheckDeletedNodepools,
-           shouldCheckDeletedDisks,
-           shouldCheckInitBuckets,
-           shouldCheckDataprocWorkers
-          ) =>
-            ResourceValidator
-              .run[IO](
-                isDryRun = dryRun,
-                shouldCheckAll = checkAll,
-                shouldCheckDeletedRuntimes = shouldCheckDeletedRuntimes,
-                shouldCheckErroredRuntimes = shouldCheckErroredRuntimes,
-                shouldCheckStoppedRuntimes = shouldCheckStoppedRuntimes,
-                shouldCheckDeletedKubernetesCluster = shouldCheckDeletedKubernetesClusters,
-                shouldCheckDeletedNodepool = shouldCheckDeletedNodepools,
-                shouldCheckDeletedDisks = shouldCheckDeletedDisks,
-                shouldCheckInitBuckets = shouldCheckInitBuckets,
-                shouldCheckDataprocWorkers = shouldCheckDataprocWorkers
-              )
-              .compile
-              .drain
-              .unsafeRunSync()
-        }
-      }
-    )
+    (enableDryRun,
+     shouldCheckAll,
+     shouldCheckDeletedRuntimes,
+     shouldCheckErroredRuntimes,
+     shouldCheckStoppedRuntimes,
+     shouldCheckDeletedKubernetesClusters,
+     shouldCheckDeletedNodepools,
+     shouldCheckDeletedDisks,
+     shouldCheckInitBuckets,
+     shouldCheckDataprocWorkers
+    ).mapN {
+      (dryRun,
+       checkAll,
+       shouldCheckDeletedRuntimes,
+       shouldCheckErroredRuntimes,
+       shouldCheckStoppedRuntimes,
+       shouldCheckDeletedKubernetesClusters,
+       shouldCheckDeletedNodepools,
+       shouldCheckDeletedDisks,
+       shouldCheckInitBuckets,
+       shouldCheckDataprocWorkers
+      ) =>
+        ResourceValidator
+          .run[IO](
+            isDryRun = dryRun,
+            shouldCheckAll = checkAll,
+            shouldCheckDeletedRuntimes = shouldCheckDeletedRuntimes,
+            shouldCheckErroredRuntimes = shouldCheckErroredRuntimes,
+            shouldCheckStoppedRuntimes = shouldCheckStoppedRuntimes,
+            shouldCheckDeletedKubernetesCluster = shouldCheckDeletedKubernetesClusters,
+            shouldCheckDeletedNodepool = shouldCheckDeletedNodepools,
+            shouldCheckDeletedDisks = shouldCheckDeletedDisks,
+            shouldCheckInitBuckets = shouldCheckInitBuckets,
+            shouldCheckDataprocWorkers = shouldCheckDataprocWorkers
+          )
+          .compile
+          .drain
+          .as(ExitCode.Success)
+    }
+  }
+}

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
@@ -98,7 +98,7 @@ object ResourceValidator {
       ).covary[F]
 
       _ <- processes.parJoin(8) // Number of checkers in 'processes'
-    } yield ExitCode.Success
+    } yield ()
   }.drain
 
   private def initDependencies[F[_]: Async: StructuredLogger: Parallel](

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Main.scala
@@ -1,37 +1,37 @@
 package com.broadinstitute.dsp.zombieMonitor
 
-import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import cats.effect.{ExitCode, IO}
 import cats.syntax.all._
-import com.monovore.decline.{CommandApp, _}
+import com.monovore.decline.effect.CommandIOApp
+import com.monovore.decline._
 
 object Main
-    extends CommandApp(
-      name = "zombie-monitor",
-      header = "Update Leonardo database to reflect google resource status",
-      version = "0.0.1",
-      main = {
-        val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
-        val shouldRunAll = Opts.flag("all", "run all checks").orFalse
-        val shouldCheckDeletedOrErrorRuntimes =
-          Opts.flag("checkDeletedOrErroredRuntimes", "check all deleted or error-ed runtimes").orFalse
-        val shouldCheckDeletedDisks = Opts.flag("checkDeletedDisks", "check all deleted runtimes").orFalse
-        val shouldCheckDeletedK8sClusters = Opts.flag("checkDeletedK8sClusters", "check all deleted clusters").orFalse
-        val shouldCheckDeletedOrErroredNodepools =
-          Opts.flag("checkDeletedNodepools", "check all deleted or errored nodepools").orFalse
+    extends CommandIOApp(name = "zombie-monitor",
+                         header = "Update Leonardo database to reflect google resource status",
+                         version = "2022.1.5"
+    ) {
+  override def main: Opts[IO[ExitCode]] = {
+    val enableDryRun = Opts.flag("dryRun", "Default to true").orFalse.withDefault(true)
+    val shouldRunAll = Opts.flag("all", "run all checks").orFalse
+    val shouldCheckDeletedOrErrorRuntimes =
+      Opts.flag("checkDeletedOrErroredRuntimes", "check all deleted or error-ed runtimes").orFalse
+    val shouldCheckDeletedDisks = Opts.flag("checkDeletedDisks", "check all deleted runtimes").orFalse
+    val shouldCheckDeletedK8sClusters = Opts.flag("checkDeletedK8sClusters", "check all deleted clusters").orFalse
+    val shouldCheckDeletedOrErroredNodepools =
+      Opts.flag("checkDeletedNodepools", "check all deleted or errored nodepools").orFalse
 
-        (enableDryRun,
-         shouldRunAll,
-         shouldCheckDeletedOrErrorRuntimes,
-         shouldCheckDeletedDisks,
-         shouldCheckDeletedK8sClusters,
-         shouldCheckDeletedOrErroredNodepools
-        ).mapN { (dryRun, runAll, runCheckDeletedRuntimes, checkDisks, runCheckDeletedK8sClusters, checkNodepools) =>
-          ZombieMonitor
-            .run[IO](dryRun, runAll, runCheckDeletedRuntimes, checkDisks, runCheckDeletedK8sClusters, checkNodepools)
-            .compile
-            .drain
-            .unsafeRunSync()
-        }
-      }
-    )
+    (enableDryRun,
+     shouldRunAll,
+     shouldCheckDeletedOrErrorRuntimes,
+     shouldCheckDeletedDisks,
+     shouldCheckDeletedK8sClusters,
+     shouldCheckDeletedOrErroredNodepools
+    ).mapN { (dryRun, runAll, runCheckDeletedRuntimes, checkDisks, runCheckDeletedK8sClusters, checkNodepools) =>
+      ZombieMonitor
+        .run[IO](dryRun, runAll, runCheckDeletedRuntimes, checkDisks, runCheckDeletedK8sClusters, checkNodepools)
+        .compile
+        .drain
+        .as(ExitCode.Success)
+    }
+  }
+}

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -3,7 +3,7 @@ package zombieMonitor
 
 import cats.Parallel
 import cats.effect.std.Semaphore
-import cats.effect.{Async, ExitCode, Resource}
+import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.broadinstitute.dsp.JsonCodec.serviceDataEncoder
 import fs2.Stream
@@ -67,7 +67,7 @@ object ZombieMonitor {
       ).covary[F]
 
       _ <- processes.parJoin(4) // Number of checkers in 'processes'
-    } yield ExitCode.Success
+    } yield ()
   }.drain
 
   private def initDependencies[F[_]: Async: StructuredLogger: Parallel](


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3005

In current code, because `goog-compute-???` threads aren't daemon threads, they'll prevent JVM from shutting down properly. It shutsdown just fine via `sbt` for some reason, but issue is exposed when deployed running in a container.

See error
```
Non-daemon threads currently preventing JVM termination: - 299: Thread[DestroyJavaVM,5,main]
```

Depends on https://github.com/broadinstitute/workbench-libs/pull/864