### PR TITLE
IA-3005 bump wb-libs

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val workbenchGoogle2Version = "0.23-fdc25f3"
+  val workbenchGoogle2Version = "0.23-3b927f8"
   val doobieVersion = "1.0.0-RC1"
   val openTelemetryVersion = "0.2-03a7abb"
   val declineVersion = "2.2.0"


### PR DESCRIPTION
Similar to https://github.com/broadinstitute/leonardo-cron-jobs/pull/174.

Relevant wb-libs PR https://github.com/broadinstitute/workbench-libs/pull/872

The previous PR fixed zombie monitor. But the resourceValidator and janitor uses pubsub, which also uses non daemon threads. 