### PR TITLE
[no ticket] not try to delete kubernetes cluster if billing is disabled

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
@@ -4,7 +4,7 @@ import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GooglePublisher, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleBillingService, GooglePublisher, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
@@ -77,4 +77,4 @@ final case class CheckRunnerDeps[F[_]](reportDestinationBucket: GcsBucketName,
                                        storageService: GoogleStorageService[F],
                                        metrics: OpenTelemetryMetrics[F]
 )
-final case class LeoPublisherDeps[F[_]](publisher: GooglePublisher[F], checkRunnerDeps: CheckRunnerDeps[F])
+final case class LeoPublisherDeps[F[_]](publisher: GooglePublisher[F], checkRunnerDeps: CheckRunnerDeps[F], billingService: GoogleBillingService[F])

--- a/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/CheckRunner.scala
@@ -4,7 +4,12 @@ import cats.effect.Async
 import cats.mtl.Ask
 import cats.syntax.all._
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleBillingService, GooglePublisher, GoogleStorageService}
+import org.broadinstitute.dsde.workbench.google2.{
+  GcsBlobName,
+  GoogleBillingService,
+  GooglePublisher,
+  GoogleStorageService
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
@@ -77,4 +82,7 @@ final case class CheckRunnerDeps[F[_]](reportDestinationBucket: GcsBucketName,
                                        storageService: GoogleStorageService[F],
                                        metrics: OpenTelemetryMetrics[F]
 )
-final case class LeoPublisherDeps[F[_]](publisher: GooglePublisher[F], checkRunnerDeps: CheckRunnerDeps[F], billingService: GoogleBillingService[F])
+final case class LeoPublisherDeps[F[_]](publisher: GooglePublisher[F],
+                                        checkRunnerDeps: CheckRunnerDeps[F],
+                                        billingService: GoogleBillingService[F]
+)

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
@@ -38,12 +38,14 @@ object KubernetesClusterRemover {
       ): F[Option[KubernetesClusterToRemove]] =
         for {
           now <- F.realTimeInstant
+          isBillingEnabled <- deps.billingService.isBillingEnabled(c.googleProject)
           _ <-
-            if (!isDryRun) {
+            if (!isDryRun && isBillingEnabled) {
               val msg = DeleteKubernetesClusterMessage(c.id, c.googleProject, TraceId(s"kubernetesClusterRemover-$now"))
               deps.publisher.publishOne(msg)
             } else F.unit
-        } yield Some(c)
+          res = if(isBillingEnabled) Some(c) else None
+        } yield res
     }
 }
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
@@ -44,7 +44,7 @@ object KubernetesClusterRemover {
               val msg = DeleteKubernetesClusterMessage(c.id, c.googleProject, TraceId(s"kubernetesClusterRemover-$now"))
               deps.publisher.publishOne(msg)
             } else F.unit
-          res = if(isBillingEnabled) Some(c) else None
+          res = if (isBillingEnabled) Some(c) else None
         } yield res
     }
 }

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -7,7 +7,11 @@ import com.broadinstitute.dsp.Generators._
 import fs2.Stream
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.{GoogleBillingService, GooglePublisher}
-import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleBillingInterpreter, FakeGooglePublisher, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeGoogleBillingInterpreter,
+  FakeGooglePublisher,
+  FakeGoogleStorageInterpreter
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -48,8 +52,9 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
 
   it should "do nothing if billing is not enabled" in {
     forAll { (clusterToRemove: KubernetesClusterToRemove, dryRun: Boolean) =>
-      val billingService = new FakeGoogleBillingInterpreter{
-        override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(false)
+      val billingService = new FakeGoogleBillingInterpreter {
+        override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] =
+          IO.pure(false)
       }
       val dbReader = new FakeDbReader {
         override def getKubernetesClustersToDelete: Stream[IO, KubernetesClusterToRemove] =
@@ -72,7 +77,9 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
     }
   }
 
-  private def initDeps(publisher: GooglePublisher[IO], billingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter): LeoPublisherDeps[IO] = {
+  private def initDeps(publisher: GooglePublisher[IO],
+                       billingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter
+  ): LeoPublisherDeps[IO] = {
     val checkRunnerDeps =
       CheckRunnerDeps(ConfigSpec.config.reportDestinationBucket,
                       FakeGoogleStorageInterpreter,

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -6,12 +6,13 @@ import cats.mtl.Ask
 import com.broadinstitute.dsp.Generators._
 import fs2.Stream
 import io.circe.Encoder
-import org.broadinstitute.dsde.workbench.google2.GooglePublisher
-import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.{GoogleBillingService, GooglePublisher}
+import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleBillingInterpreter, FakeGooglePublisher, FakeGoogleStorageInterpreter}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "send DeleteKubernetesClusterMessage when clusters are detected to be auto-deleted" in {
     forAll { (clusterToRemove: KubernetesClusterToRemove, dryRun: Boolean) =>
@@ -45,12 +46,38 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
     }
   }
 
-  private def initDeps(publisher: GooglePublisher[IO]): LeoPublisherDeps[IO] = {
+  it should "do nothing if billing is not enabled" in {
+    forAll { (clusterToRemove: KubernetesClusterToRemove, dryRun: Boolean) =>
+      val billingService = new FakeGoogleBillingInterpreter{
+        override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(false)
+      }
+      val dbReader = new FakeDbReader {
+        override def getKubernetesClustersToDelete: Stream[IO, KubernetesClusterToRemove] =
+          Stream.emit(clusterToRemove)
+      }
+
+      val publisher = new FakeGooglePublisher {
+        override def publishOne[MessageType](message: MessageType)(implicit
+          evidence$2: Encoder[MessageType],
+          ev: Ask[IO, TraceId]
+        ): IO[Unit] =
+          IO.raiseError(fail("Shouldn't publish message"))
+      }
+
+      val deps = initDeps(publisher, billingService)
+      val checker = KubernetesClusterRemover.impl(dbReader, deps)
+      val res = checker.checkResource(clusterToRemove, dryRun)
+
+      res.unsafeRunSync() shouldBe None
+    }
+  }
+
+  private def initDeps(publisher: GooglePublisher[IO], billingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter): LeoPublisherDeps[IO] = {
     val checkRunnerDeps =
       CheckRunnerDeps(ConfigSpec.config.reportDestinationBucket,
                       FakeGoogleStorageInterpreter,
                       FakeOpenTelemetryMetricsInterpreter
       )
-    new LeoPublisherDeps[IO](publisher, checkRunnerDeps)
+    new LeoPublisherDeps[IO](publisher, checkRunnerDeps, billingService)
   }
 }

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -7,7 +7,7 @@ import com.broadinstitute.dsp.Generators._
 import fs2.Stream
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
-import org.broadinstitute.dsde.workbench.google2.mock.{FakeGooglePublisher, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleBillingInterpreter, FakeGooglePublisher, FakeGoogleStorageInterpreter}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -52,6 +52,6 @@ final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
                       FakeGoogleStorageInterpreter,
                       FakeOpenTelemetryMetricsInterpreter
       )
-    new LeoPublisherDeps[IO](publisher, checkRunnerDeps)
+    new LeoPublisherDeps[IO](publisher, checkRunnerDeps, FakeGoogleBillingInterpreter)
   }
 }

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -7,7 +7,11 @@ import com.broadinstitute.dsp.Generators._
 import fs2.Stream
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
-import org.broadinstitute.dsde.workbench.google2.mock.{FakeGoogleBillingInterpreter, FakeGooglePublisher, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeGoogleBillingInterpreter,
+  FakeGooglePublisher,
+  FakeGoogleStorageInterpreter
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.scalatest.flatspec.AnyFlatSpec


### PR DESCRIPTION
In Dev, we keep getting messages about delete kubernetes clusters. Those clusters live in billing projects that are already disabled, so when leo tries to disable, things will error out. Next time cron job runs, these clusters will get picked up again, and leo will fail to delete again.

This changes the cron job to ignore clusters if its project doesn't have billing enabled