### PR TITLE
[IA-3281] dealing with existing azure entries in dev

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -47,7 +47,7 @@ object DbReaderImplicits {
       case (id, cloudContextDb, cloudProvider, runtimeName, cloudService, status, zone, region) =>
         cloudProvider match {
           case CloudProvider.Azure =>
-            throw new NotImplementedError()
+            Runtime.AzureVM(id, runtimeName, cloudService, status)
           case CloudProvider.Gcp =>
             (zone, region) match {
               case (Some(_), Some(_)) =>

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -47,6 +47,7 @@ object DbReaderImplicits {
       case (id, cloudContextDb, cloudProvider, runtimeName, cloudService, status, zone, region) =>
         cloudProvider match {
           case CloudProvider.Azure =>
+            //TODO: IA-3289 correctly implement this case in the pattern match once we support Azure
             Runtime.AzureVM(id, runtimeName, cloudService, status)
           case CloudProvider.Gcp =>
             (zone, region) match {

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -47,7 +47,7 @@ object DbReaderImplicits {
       case (id, cloudContextDb, cloudProvider, runtimeName, cloudService, status, zone, region) =>
         cloudProvider match {
           case CloudProvider.Azure =>
-            //TODO: IA-3289 correctly implement this case in the pattern match once we support Azure
+            // TODO: IA-3289 correctly implement this case in the pattern match once we support Azure
             Runtime.AzureVM(id, runtimeName, cloudService, status)
           case CloudProvider.Gcp =>
             (zone, region) match {


### PR DESCRIPTION
Dev Cron job is still erroring. This is because of existing Azure entries in the DB. The Cron job will try to check these entries which correctly threw the NotImplementedError. We removed the error throwing in this case. I added a TODO to correctly implement this once we do support Azure