### PR TITLE
IA-3480 delete "Deleting" disk as well

### DIFF
--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
@@ -17,7 +17,7 @@ final class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with I
   val transactor = yoloTransactor
 
   it should "build deletedDisksQuery properly" taggedAs DbTest in {
-    check(DbReader.deletedDisksQuery)
+    check(DbReader.shouldBedeletedDisksQuery)
   }
 
   it should "build initBucketsToDeleteQuery properly" taggedAs DbTest in {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3480

Disks that're in "Deleting" status means at some point there was user request to delete these disks, but somehow they're stuck in deleting. So we're discovering these disks and deleting them in GCP.

Once these disks are actually deleted in GCP, they'll be picked up by zombie monitor and leo DB will reflect the right status from then on.