### PR TITLE
IA-3289 address azure runtime as well in resource-validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 application.conf
 sqlproxy.env
 .bsp
+application.conf.qi

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -55,7 +55,6 @@ object DbReaderImplicits {
       case (id, cloudContextDb, cloudProvider, runtimeName, cloudService, status, zone, region) =>
         cloudProvider match {
           case CloudProvider.Azure =>
-            // TODO: IA-3289 correctly implement this case in the pattern match once we support Azure
             AzureCloudContext.fromString(cloudContextDb) match {
               case Left(value) =>
                 throw new RuntimeException(

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -2,6 +2,7 @@ package com.broadinstitute.dsp
 
 import ca.mrvisser.sealerate
 import io.circe.Encoder
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, ZoneName}
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{
   KubernetesClusterId,
@@ -125,8 +126,8 @@ object CloudContext {
     override val asStringWithProvider = s"Gcp/${value.value}"
     override def cloudProvider: CloudProvider = CloudProvider.Gcp
   }
-  final case class Azure(value: String) extends CloudContext {
-    override val asString = value
+  final case class Azure(value: AzureCloudContext) extends CloudContext {
+    override val asString = value.asString
     override val asStringWithProvider = s"Azure/${value}"
     override def cloudProvider: CloudProvider = CloudProvider.Azure
   }
@@ -147,3 +148,5 @@ object JsonCodec {
 final case class ServiceData(version: Option[String]) {
   val name = "leonardo-cron-jobs"
 }
+
+final case class Prometheus(port: Int)

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
 import org.scalacheck.{Arbitrary, Gen}
 import org.broadinstitute.dsde.workbench.google2.Generators._
+import org.broadinstitute.dsde.workbench.azure.Generators.genAzureCloudContext
 
 object Generators {
   // TODO IA-3289 When we implement Azure, make sure to add CloudService.AzureVM as an option in the line below so tests use it
@@ -12,6 +13,7 @@ object Generators {
     id <- Gen.chooseNum(0, 100)
     cloudService <- genCloudService
     project <- genGoogleProject
+    azureCloudContext <- genAzureCloudContext
     runtimeName <- Gen.uuid.map(_.toString)
     status <- possibleStatuses.fold(Gen.oneOf("Running", "Creating", "Deleted", "Error"))(s => Gen.oneOf(s.toList))
   } yield cloudService match {
@@ -20,7 +22,7 @@ object Generators {
     case CloudService.Gce =>
       Runtime.Gce(id, project, runtimeName, cloudService, status, DBTestHelper.zoneName)
     case CloudService.AzureVM =>
-      Runtime.AzureVM(id, runtimeName, cloudService, status)
+      Runtime.AzureVM(id, CloudContext.Azure(azureCloudContext), runtimeName, cloudService, status)
   }
   val genDataprocRuntime: Gen[Runtime.Dataproc] = for {
     id <- Gen.chooseNum(0, 100)

--- a/janitor/src/main/resources/reference.conf
+++ b/janitor/src/main/resources/reference.conf
@@ -19,4 +19,10 @@ report-destination-bucket = "replace-me"
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
+
+  azure-app-registration {
+    client-id = ${LEONARDO_AZURE_APP_CLIENT_ID}
+    client-secret = ${LEONARDO_AZURE_APP_CLIENT_SECRET}
+    managed-app-tenant-id = ${LEONARDO_AZURE_APP_TENANT_ID}
+  }
 }

--- a/janitor/src/main/resources/reference.conf
+++ b/janitor/src/main/resources/reference.conf
@@ -1,5 +1,9 @@
 path-to-credential = ${LEONARDO_PATH_TO_CREDENTIAL}
 
+prometheus {
+  port = 9098
+}
+
 database {
   url = "jdbc:mysql://127.0.0.1:3306/leonardo?rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&autoReconnect=true"
   user = ${LEONARDO_DB_USER}

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Config.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Config.scala
@@ -20,5 +20,6 @@ final case class AppConfig(database: DatabaseConfig,
                            pathToCredential: Path,
                            reportDestinationBucket: GcsBucketName,
                            runtimeCheckerConfig: RuntimeCheckerConfig,
-                           leonardoPubsub: PubsubConfig
+                           leonardoPubsub: PubsubConfig,
+                           prometheus: Prometheus
 )

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Janitor.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Janitor.scala
@@ -62,7 +62,7 @@ object Janitor {
   ): Resource[F, JanitorDeps[F]] =
     for {
       blockerBound <- Resource.eval(Semaphore[F](250))
-      metrics <- OpenTelemetryMetrics.resource(appConfig.pathToCredential, "leonardo-cron-jobs")
+      metrics <- OpenTelemetryMetrics.resource("leonardo-cron-jobs", appConfig.prometheus.port)
       runtimeCheckerDeps <- RuntimeCheckerDeps.init(appConfig.runtimeCheckerConfig, metrics, blockerBound)
       publisherConfig = PublisherConfig(
         appConfig.pathToCredential.toString,

--- a/janitor/src/test/resources/reference.conf
+++ b/janitor/src/test/resources/reference.conf
@@ -11,3 +11,11 @@ report-destination-bucket = "test-bucket"
 leonardo-pubsub {
   google-project = "test-project"
 }
+
+runtime-checker-config {
+  azure-app-registration {
+    client-id = ""
+    client-secret = ""
+    managed-app-tenant-id = ""
+  }
+}

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/ConfigSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/ConfigSpec.scala
@@ -1,8 +1,9 @@
 package com.broadinstitute.dsp
 package janitor
 
-import java.nio.file.Paths
+import org.broadinstitute.dsde.workbench.azure.{AzureAppRegistrationConfig, ClientId, ClientSecret, ManagedAppTenantId}
 
+import java.nio.file.Paths
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,12 +23,14 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       expectedReportDestinationBucket,
       RuntimeCheckerConfig(
         expectedPathToCredential,
-        expectedReportDestinationBucket
+        expectedReportDestinationBucket,
+        AzureAppRegistrationConfig(ClientId(""), ClientSecret(""), ManagedAppTenantId(""))
       ),
       PubsubConfig(
         GoogleProject("test-project"),
         "leonardo-pubsub"
-      )
+      ),
+      Prometheus(9098)
     )
 
     config shouldBe Right(expectedConfig)

--- a/nuker/src/main/resources/reference.conf
+++ b/nuker/src/main/resources/reference.conf
@@ -1,5 +1,9 @@
 path-to-credential = ${LEONARDO_PATH_TO_CREDENTIAL}
 
+prometheus {
+  port = 9098
+}
+
 pubsub-topic-cleaner {
   google-project = "replace-me"
 }

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Config.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Config.scala
@@ -14,4 +14,4 @@ object Config {
     .leftMap(failures => new RuntimeException(failures.toList.map(_.description).mkString("\n")))
 }
 
-final case class AppConfig(pubsubTopicCleaner: PubsubTopicCleanerConfig, pathToCredential: Path)
+final case class AppConfig(pubsubTopicCleaner: PubsubTopicCleanerConfig, pathToCredential: Path, prometheus: Prometheus)

--- a/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
+++ b/nuker/src/main/scala/com/broadinstitute/dsp/nuker/Nuker.scala
@@ -45,7 +45,7 @@ object Nuker {
     appConfig: AppConfig
   ): Resource[F, NukerDeps[F]] =
     for {
-      metrics <- OpenTelemetryMetrics.resource(appConfig.pathToCredential, "leonardo-cron-jobs")
+      metrics <- OpenTelemetryMetrics.resource("leonardo-cron-jobs", appConfig.prometheus.port)
       credential <- org.broadinstitute.dsde.workbench.google2.credentialResource[F](appConfig.pathToCredential.toString)
       topicAdminClient <- GoogleTopicAdmin.fromServiceAccountCrendential(credential)
       subscriptionClient <- GoogleSubscriptionAdmin.fromServiceAccountCredential(credential)

--- a/nuker/src/test/scala/com/broadinstitute/dsp/nuker/ConfigSpec.scala
+++ b/nuker/src/test/scala/com/broadinstitute/dsp/nuker/ConfigSpec.scala
@@ -13,7 +13,8 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
     val expectedPathToCredential = Paths.get("path-to-credential")
     val expectedConfig = AppConfig(
       PubsubTopicCleanerConfig(GoogleProject("replace-me")),
-      expectedPathToCredential
+      expectedPathToCredential,
+      Prometheus(9098)
     )
 
     config shouldBe Right(expectedConfig)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.17.1",
     "mysql" % "mysql-connector-java" % "8.0.27",
-    "org.scalatest" %% "scalatest" % "3.2.10" % Test,
+    "org.scalatest" %% "scalatest" % "3.2.11" % Test,
     "com.monovore" %% "decline" % declineVersion,
     "com.monovore" %% "decline-effect" % declineVersion,
     "dev.optics" %% "monocle-core" % "3.1.0",
@@ -28,8 +28,8 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version % Test classifier "tests",
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureVersion,
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureVersion % Test classifier "tests",
-    "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
-    "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,
+    "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
     "ca.mrvisser" %% "sealerate" % "0.0.6"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val workbenchLibsHash = "25263dc1-SNAP"
+  val workbenchLibsHash = "3159fd9"
   val workbenchGoogle2Version = s"0.24-${workbenchLibsHash}"
   val workbenchAzureVersion = s"0.1-${workbenchLibsHash}"
   val openTelemetryVersion = s"0.3-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,14 +9,14 @@ object Dependencies {
   val declineVersion = "2.2.0"
 
   val core = Seq(
-    "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1",
-    "ch.qos.logback" % "logback-classic" % "1.2.10",
-    "ch.qos.logback" % "logback-core" % "1.2.10",
+    "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1",
+    "ch.qos.logback" % "logback-classic" % "1.2.11",
+    "ch.qos.logback" % "logback-core" % "1.2.11",
     "org.tpolecat" %% "doobie-core" % doobieVersion,
     "org.tpolecat" %% "doobie-hikari" % doobieVersion,
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.17.1",
-    "mysql" % "mysql-connector-java" % "8.0.27",
+    "mysql" % "mysql-connector-java" % "8.0.29",
     "org.scalatest" %% "scalatest" % "3.2.11" % Test,
     "com.monovore" %% "decline" % declineVersion,
     "com.monovore" %% "decline-effect" % declineVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,11 @@
 import sbt._
 
 object Dependencies {
-  val workbenchGoogle2Version = "0.23-3b927f8"
+  val workbenchLibsHash = "25263dc1-SNAP"
+  val workbenchGoogle2Version = s"0.24-${workbenchLibsHash}"
+  val workbenchAzureVersion = s"0.1-${workbenchLibsHash}"
+  val openTelemetryVersion = s"0.3-${workbenchLibsHash}"
   val doobieVersion = "1.0.0-RC2"
-  val openTelemetryVersion = "0.2-03a7abb"
   val declineVersion = "2.2.0"
 
   val core = Seq(
@@ -23,8 +25,9 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion,
     "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % openTelemetryVersion % Test classifier "tests",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version,
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2Version % Test classifier "tests",
+    "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureVersion,
+    "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureVersion % Test classifier "tests",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
     "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
     "ca.mrvisser" %% "sealerate" % "0.0.6"

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -5,6 +5,7 @@ object Merging {
     case PathList("io", "sundr", _ @_*)                   => MergeStrategy.first
     case PathList("org", "bouncycastle", _ @_*)           => MergeStrategy.first
     case PathList("com", "google", "code", "gson", _ @_*) => MergeStrategy.first
+    case x if x.contains("io.netty.versions.properties")  => MergeStrategy.first
     case "reference.conf"                                 => MergeStrategy.concat
     case x if x.endsWith("/module-info.class") =>
       MergeStrategy.discard // JDK 8 does not use the file module-info.class so it is safe to discard the file.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
 
   private lazy val commonSettings = List(
     organization := "com.broadinstitute.dsp",
-    scalaVersion := "2.13.7",
+    scalaVersion := "2.13.8",
     resolvers ++= commonResolvers,
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -84,7 +84,7 @@ object Settings {
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
     // Docker settings
     maintainer := "workbench-interactive-analysis@broadinstitute.org",
-    dockerBaseImage := "us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian",
+    dockerBaseImage := "us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian",
     dockerRepository := Some("us.gcr.io"),
     // Resolve trivy errors related to glibc (CVE-2019-9169)
     // TODO Hopefully this will be fixed in an upcoming version of graalvm-ce

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.6.1
+sbt.version=1.6.2
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.6.2
-
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.7")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")

--- a/resource-validator/src/main/resources/reference.conf
+++ b/resource-validator/src/main/resources/reference.conf
@@ -19,4 +19,10 @@ report-destination-bucket = "replace-me"
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
+
+  azure-app-registration {
+    client-id = ${LEONARDO_AZURE_APP_CLIENT_ID}
+    client-secret = ${LEONARDO_AZURE_APP_CLIENT_SECRET}
+    managed-app-tenant-id = ${LEONARDO_AZURE_APP_TENANT_ID}
+  }
 }

--- a/resource-validator/src/main/resources/reference.conf
+++ b/resource-validator/src/main/resources/reference.conf
@@ -1,5 +1,9 @@
 path-to-credential = ${LEONARDO_PATH_TO_CREDENTIAL}
 
+prometheus {
+  port = 9098
+}
+
 database {
   url = "jdbc:mysql://127.0.0.1:3306/leonardo?rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&autoReconnect=true"
   user = ${LEONARDO_DB_USER}

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Config.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/Config.scala
@@ -20,5 +20,6 @@ final case class AppConfig(database: DatabaseConfig,
                            pathToCredential: Path,
                            reportDestinationBucket: GcsBucketName,
                            runtimeCheckerConfig: RuntimeCheckerConfig,
-                           leonardoPubsub: PubsubConfig
+                           leonardoPubsub: PubsubConfig,
+                           prometheus: Prometheus
 )

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeChecker.scala
@@ -4,8 +4,9 @@ package resourceValidator
 import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
+import org.broadinstitute.dsde.workbench.google2.DataprocClusterName
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]
@@ -88,14 +89,14 @@ object DeletedRuntimeChecker {
       private def checkAzureRuntime(runtime: Runtime.AzureVM, isDryRun: Boolean): F[Option[Runtime]] =
         for {
           runtimeOpt <- deps.azureVmService
-            .getAzureVm(runtime.runtimeName, runtime.cloudContext.value)
+            .getAzureVm(InstanceName(runtime.runtimeName), runtime.cloudContext.value)
           _ <- runtimeOpt.traverse_ { _ =>
             if (isDryRun)
               logger.warn(s"${runtime} still exists in Azure. It needs to be deleted")
             else
               logger.warn(s"${runtime} still exists in Azure. Going to delete") >>
                 deps.azureVmService
-                  .deleteAzureVm(runtime.runtimeName, runtime.cloudContext.value, true)
+                  .deleteAzureVm(InstanceName(runtime.runtimeName), runtime.cloudContext.value, true)
                   .void
           }
         } yield runtimeOpt.fold(none[Runtime])(_ => Some(runtime))

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/ResourceValidator.scala
@@ -106,7 +106,7 @@ object ResourceValidator {
   ): Resource[F, ResourcevalidatorServerDeps[F]] =
     for {
       blockerBound <- Resource.eval(Semaphore[F](250))
-      metrics <- OpenTelemetryMetrics.resource(appConfig.pathToCredential, "leonardo-cron-jobs")
+      metrics <- OpenTelemetryMetrics.resource("leonardo-cron-jobs", appConfig.prometheus.port)
       runtimeCheckerDeps <- RuntimeCheckerDeps.init(appConfig.runtimeCheckerConfig, metrics, blockerBound)
       diskService <- GoogleDiskService.resource(appConfig.pathToCredential.toString, blockerBound)
       publisherConfig = PublisherConfig(

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -44,11 +44,15 @@ object StoppedRuntimeChecker {
           runtimeOpt <- deps.computeService
             .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
           runningRuntimeOpt <- runtimeOpt.flatTraverse { rt =>
-            if (rt.getStatus.toUpperCase == Instance.Status.RUNNING.name().toUpperCase)
+            val expectedStatus =
+              Set(Instance.Status.STOPPED.name().toUpperCase, Instance.Status.TERMINATED.name().toUpperCase())
+            if (!expectedStatus.contains(rt.getStatus.toUpperCase))
               if (isDryRun)
-                logger.warn(s"${runtime} is running. It needs to be stopped.").as[Option[Runtime]](Some(runtime))
+                logger
+                  .warn(s"${runtime} is ${rt.getStatus}. It needs to be stopped.")
+                  .as[Option[Runtime]](Some(runtime))
               else
-                logger.warn(s"${runtime} is running. Going to stop it.") >>
+                logger.warn(s"${runtime} is ${rt.getStatus}. Going to stop it.") >>
                   // In contrast to in Leo, we're not setting the shutdown script metadata before stopping the instance
                   // in order to keep things simple since our main goal here is to prevent unintended cost to users.
                   deps.computeService

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -7,8 +7,9 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.ClusterStatus
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
+import org.broadinstitute.dsde.workbench.google2.DataprocClusterName
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.typelevel.log4cats.Logger
 
 // Implements CheckRunner[F[_], A]

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -31,7 +31,7 @@ object StoppedRuntimeChecker {
             checkDataprocCluster(x, isDryRun)
           case x: Runtime.Gce =>
             checkGceRuntime(x, isDryRun)
-          case x: Runtime.AzureVM =>
+          case _: Runtime.AzureVM =>
             // TODO: IA-3289 Implement check Azure VM
             logger.info(s"Azure VM is not supported yet").as(None)
         }
@@ -43,7 +43,7 @@ object StoppedRuntimeChecker {
           runtimeOpt <- deps.computeService
             .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
           runningRuntimeOpt <- runtimeOpt.flatTraverse { rt =>
-            if (rt.getStatus == Instance.Status.RUNNING)
+            if (rt.getStatus.toUpperCase == Instance.Status.RUNNING.name().toUpperCase)
               if (isDryRun)
                 logger.warn(s"${runtime} is running. It needs to be stopped.").as[Option[Runtime]](Some(runtime))
               else

--- a/resource-validator/src/test/resources/reference.conf
+++ b/resource-validator/src/test/resources/reference.conf
@@ -1,5 +1,13 @@
 path-to-credential = "path-to-credential"
 
+runtime-checker-config {
+  azure-app-registration {
+    client-id = ""
+    client-secret = ""
+    managed-app-tenant-id = ""
+  }
+}
+
 database {
   url = "jdbc:mysql://localhost:3311/leotestdb?createDatabaseIfNotExist=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&generateSimpleParameterMetadata=TRUE"
   user = "leonardo-test"

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ConfigSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ConfigSpec.scala
@@ -1,8 +1,9 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import java.nio.file.Paths
+import org.broadinstitute.dsde.workbench.azure.{AzureAppRegistrationConfig, ClientId, ClientSecret, ManagedAppTenantId}
 
+import java.nio.file.Paths
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,12 +23,14 @@ final class ConfigSpec extends AnyFlatSpec with Matchers {
       expectedReportDestinationBucket,
       RuntimeCheckerConfig(
         expectedPathToCredential,
-        expectedReportDestinationBucket
+        expectedReportDestinationBucket,
+        AzureAppRegistrationConfig(ClientId(""), ClientSecret(""), ManagedAppTenantId(""))
       ),
       PubsubConfig(
         GoogleProject("test-project"),
         "leonardo-pubsub"
-      )
+      ),
+      Prometheus(9098)
     )
 
     config shouldBe Right(expectedConfig)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -1,6 +1,7 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DBTestHelper.{
   getNodepoolName,
   insertK8sCluster,
@@ -8,12 +9,12 @@ import com.broadinstitute.dsp.DBTestHelper.{
   transactorResource,
   yoloTransactor
 }
-import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
+import com.broadinstitute.dsp.Generators._
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.google2.Generators.genKubernetesClusterId
 import org.scalatest.flatspec.AnyFlatSpec
-import cats.effect.unsafe.implicits.global
+
 class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
@@ -24,7 +25,7 @@ class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobs
         val dbReader = DbReader.impl(xa)
 
         val cluster2 =
-          cluster.copy(project = GoogleProject("project2"))
+          cluster.copy(project = cluster.project.copy(value = s"${cluster.project}-2"))
 
         for {
           clusterId <- insertK8sCluster(cluster)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -9,10 +9,9 @@ import com.broadinstitute.dsp.DBTestHelper.{
   transactorResource,
   yoloTransactor
 }
-import doobie.scalatest.IOChecker
 import com.broadinstitute.dsp.Generators._
+import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
-import org.broadinstitute.dsde.workbench.google2.Generators.genKubernetesClusterId
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedDiskCheckerSpec.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import cats.effect.unsafe.implicits.global
+import com.google.api.gax.longrunning.OperationFuture
 class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if disk no longer exists in Google" in {
     val diskService = new MockGoogleDiskService {
@@ -46,7 +47,8 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(implicit
           ev: Ask[IO, TraceId]
-        ): IO[Option[Operation]] = if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
+        ): IO[Option[OperationFuture[Operation, Operation]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
       val checkerDeps =
         initDeletedDiskCheckerDeps(diskService)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -13,12 +13,13 @@ import org.broadinstitute.dsde.workbench.google2.mock.{
   FakeGoogleBillingInterpreter,
   FakeGoogleComputeService
 }
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import cats.effect.unsafe.implicits.global
 import com.google.api.gax.longrunning.OperationFuture
 import com.google.protobuf.Empty
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -6,23 +6,19 @@ import cats.mtl.Ask
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper.initRuntimeCheckerDeps
 import com.google.cloud.compute.v1.{Instance, Operation}
-import com.google.cloud.dataproc.v1.Cluster
+import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.mock.{
   BaseFakeGoogleDataprocService,
   FakeGoogleBillingInterpreter,
   FakeGoogleComputeService
 }
-import org.broadinstitute.dsde.workbench.google2.{
-  DataprocClusterName,
-  DataprocOperation,
-  InstanceName,
-  RegionName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import cats.effect.unsafe.implicits.global
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.protobuf.Empty
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
@@ -66,7 +62,8 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
           ev: Ask[IO, TraceId]
-        ): IO[Option[Operation]] = if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
+        ): IO[Option[OperationFuture[Operation, Operation]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
       val dataprocService = new BaseFakeGoogleDataprocService {
         override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
@@ -78,7 +75,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[DataprocOperation]] =
+        ): IO[Option[OperationFuture[Empty, ClusterOperationMetadata]]] =
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
@@ -107,7 +104,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[DataprocOperation]] =
+        ): IO[Option[OperationFuture[Empty, ClusterOperationMetadata]]] =
           IO.pure(None)
       }
 

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -2,25 +2,21 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.mtl.Ask
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper._
+import com.google.api.gax.longrunning.OperationFuture
 import com.google.cloud.compute.v1.{Instance, Operation}
 import com.google.cloud.dataproc.v1.ClusterStatus.State
-import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
+import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata, ClusterStatus}
+import com.google.protobuf.Empty
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
-import org.broadinstitute.dsde.workbench.google2.{
-  DataprocClusterName,
-  DataprocOperation,
-  InstanceName,
-  RegionName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
-import cats.effect.unsafe.implicits.global
 class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if runtime no longer exists in Google" in {
     val computeService = new FakeGoogleComputeService {
@@ -62,7 +58,8 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
           ev: Ask[IO, TraceId]
-        ): IO[Option[Operation]] = if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
+        ): IO[Option[OperationFuture[Operation, Operation]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
       val dataprocService = new BaseFakeGoogleDataprocService {
         override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
@@ -74,7 +71,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[DataprocOperation]] =
+        ): IO[Option[OperationFuture[Empty, ClusterOperationMetadata]]] =
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
@@ -103,7 +100,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
         override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
           implicit ev: Ask[IO, TraceId]
-        ): IO[Option[DataprocOperation]] =
+        ): IO[Option[OperationFuture[Empty, ClusterOperationMetadata]]] =
           IO.raiseError(fail("this shouldn't be called"))
       }
 

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -13,9 +13,10 @@ import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata, ClusterS
 import com.google.protobuf.Empty
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalatest.flatspec.AnyFlatSpec
 class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "return None if runtime no longer exists in Google" in {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
@@ -2,6 +2,8 @@ package com.broadinstitute.dsp.resourceValidator
 
 import cats.effect.IO
 import com.broadinstitute.dsp.{CheckRunnerDeps, KubernetesClusterCheckerDeps, NodepoolCheckerDeps, RuntimeCheckerDeps}
+import org.broadinstitute.dsde.workbench.azure.AzureVmService
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
 import org.broadinstitute.dsde.workbench.google2.mock._
 import org.broadinstitute.dsde.workbench.google2.{
   GKEService,
@@ -19,13 +21,15 @@ object InitDependenciesHelper {
   def initRuntimeCheckerDeps(googleComputeService: GoogleComputeService[IO] = FakeGoogleComputeService,
                              googleStorageService: GoogleStorageService[IO] = FakeGoogleStorageInterpreter,
                              googleDataprocService: GoogleDataprocService[IO] = FakeGoogleDataprocService,
-                             googleBillingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter
+                             googleBillingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter,
+                             azureVmService: AzureVmService[IO] = FakeAzureVmService
   ) =
     RuntimeCheckerDeps(
       googleComputeService,
       googleDataprocService,
       CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter),
-      googleBillingService
+      googleBillingService,
+      azureVmService
     )
 
   def initKubernetesClusterCheckerDeps(gkeService: GKEService[IO] = MockGKEService,

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
@@ -20,7 +20,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   DataprocClusterName,
   DataprocOperation,
   DataprocRoleZonePreemptibility,
-  InstanceName,
   OperationName,
   RegionName,
   ZoneName
@@ -32,6 +31,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.Generators.genRuntime
 import com.google.api.gax.longrunning.OperationFuture
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalacheck.Arbitrary
 
 final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
@@ -10,7 +10,12 @@ import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata, ClusterStatus}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.google2.DataprocRole.{Master, SecondaryWorker, Worker}
-import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  BaseFakeGoogleDataprocService,
+  FakeComputeOperationFuture,
+  FakeDataprocClusterOperationFutureOp,
+  FakeGoogleComputeService
+}
 import org.broadinstitute.dsde.workbench.google2.{
   DataprocClusterName,
   DataprocOperation,
@@ -26,6 +31,7 @@ import com.broadinstitute.dsp.resourceValidator.StoppedRuntimeCheckerSpec._
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.Generators.genRuntime
+import com.google.api.gax.longrunning.OperationFuture
 import org.scalacheck.Arbitrary
 
 final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
@@ -67,13 +73,14 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
         override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
           ev: Ask[IO, TraceId]
         ): IO[Option[Instance]] = {
-          val instance = Instance.newBuilder().setStatus(Instance.Status.RUNNING).build()
+          val instance = Instance.newBuilder().setStatus(Instance.Status.RUNNING.toString).build()
           IO.pure(Some(instance))
         }
 
         override def stopInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
           ev: Ask[IO, TraceId]
-        ): IO[Operation] = if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(defaultOperation)
+        ): IO[OperationFuture[Operation, Operation]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(new FakeComputeOperationFuture())
       }
 
       val dataprocService = new BaseFakeGoogleDataprocService {
@@ -92,8 +99,9 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
                                  clusterName: DataprocClusterName,
                                  metadata: Option[Map[String, String]],
                                  isFullStop: Boolean
-        )(implicit ev: Ask[IO, TraceId]): IO[Option[DataprocOperation]] =
-          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(Some(defaultDataprocOperation))
+        )(implicit ev: Ask[IO, TraceId]): IO[Option[OperationFuture[Cluster, ClusterOperationMetadata]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called"))
+          else IO.pure(Some(new FakeDataprocClusterOperationFutureOp))
       }
 
       val runtimeCheckerDeps =
@@ -109,7 +117,7 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
 
 object StoppedRuntimeCheckerSpec {
   val defaultOperation = Operation.getDefaultInstance
-  val defaultDataprocOperation = new DataprocOperation(OperationName("op"), ClusterOperationMetadata.getDefaultInstance)
+  val defaultDataprocOperation = DataprocOperation(OperationName("op"), ClusterOperationMetadata.getDefaultInstance)
   val zone = ZoneName("us-central1-a")
   val dataprocRoleZonePreemptibilityInstances = Map(
     DataprocRoleZonePreemptibility(Master, zone, false) -> Set(InstanceName("master-instance")),

--- a/zombie-monitor/src/main/resources/reference.conf
+++ b/zombie-monitor/src/main/resources/reference.conf
@@ -13,3 +13,6 @@ runtime-checker-config {
   report-destination-bucket = ${report-destination-bucket}
 }
 
+prometheus {
+  port = 9098
+}

--- a/zombie-monitor/src/main/resources/reference.conf
+++ b/zombie-monitor/src/main/resources/reference.conf
@@ -11,6 +11,12 @@ report-destination-bucket = "replace-me"
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
+
+  azure-app-registration {
+    client-id = ${LEONARDO_AZURE_APP_CLIENT_ID}
+    client-secret = ${LEONARDO_AZURE_APP_CLIENT_SECRET}
+    managed-app-tenant-id = ${LEONARDO_AZURE_APP_TENANT_ID}
+  }
 }
 
 prometheus {

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
@@ -6,8 +6,9 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.cloud.compute.v1.Instance
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, InstanceName}
+import org.broadinstitute.dsde.workbench.google2.DataprocClusterName
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.typelevel.log4cats.Logger
 
 /**
@@ -130,7 +131,7 @@ object ActiveRuntimeChecker {
       def checkAzureRuntimeStatus(runtime: Runtime.AzureVM, isDryRun: Boolean): F[Option[Runtime]] =
         for {
           runtimeOpt <- deps.azureVmService
-            .getAzureVm(runtime.runtimeName, runtime.cloudContext.value)
+            .getAzureVm(InstanceName(runtime.runtimeName), runtime.cloudContext.value)
           res <-
             runtimeOpt match {
               case None =>

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
@@ -34,8 +34,7 @@ object ActiveRuntimeChecker {
           case x: Runtime.Gce =>
             checkGceRuntimeStatus(x, isDryRun)
           case x: Runtime.AzureVM =>
-            // TODO: IA-3289 Implement check Azure VM
-            logger.info(s"Azure VM is not supported yet").as(None)
+            checkAzureRuntimeStatus(x, isDryRun)
         }
 
       def checkDataprocClusterStatus(runtime: Runtime.Dataproc, isDryRun: Boolean)(implicit
@@ -112,8 +111,11 @@ object ActiveRuntimeChecker {
               case None =>
                 if (isDryRun) logger.info(s"Not updating DB ${runtime} to be Deleted").as(runtime.some)
                 else dbReader.markRuntimeDeleted(runtime.id).as(runtime.some)
-              case Some(r) if runtime.status.toUpperCase == r.getStatus.toString => F.pure(none[Runtime])
-              case Some(r) if r.getStatus == Instance.Status.TERMINATED && runtime.status != "Stopped" =>
+              case Some(r) if runtime.status.toUpperCase == r.getStatus.toUpperCase() => F.pure(none[Runtime])
+              case Some(r)
+                  if r.getStatus.toUpperCase == Instance.Status.TERMINATED
+                    .name()
+                    .toUpperCase && runtime.status != "Stopped" =>
                 if (isDryRun) logger.info(s"Not updating ${runtime} to be Stopped").as(runtime.some)
                 else dbReader.updateRuntimeStatus(runtime.id, "Stopped").as(runtime.some)
               case Some(r) =>
@@ -122,6 +124,23 @@ object ActiveRuntimeChecker {
                     s"${runtime} is ${runtime.status} in Leonardo, but it's actually in ${r.getStatus} status in Google"
                   )
                   .as(none[Runtime])
+            }
+        } yield res
+
+      def checkAzureRuntimeStatus(runtime: Runtime.AzureVM, isDryRun: Boolean): F[Option[Runtime]] =
+        for {
+          runtimeOpt <- deps.azureVmService
+            .getAzureVm(runtime.runtimeName, runtime.cloudContext.value)
+          res <-
+            runtimeOpt match {
+              case None =>
+                if (isDryRun) logger.info(s"Not updating DB ${runtime} to be Deleted").as(runtime.some)
+                else dbReader.markRuntimeDeleted(runtime.id).as(runtime.some)
+              case Some(r) =>
+                // TODO: update this once we understand more about Azure VM statuses
+                logger.info(s"Not updating DB ${runtime}. Its azure status is ${r.powerState().toString}") >> F.pure(
+                  none[Runtime]
+                )
             }
         } yield res
     }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Config.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/Config.scala
@@ -19,5 +19,6 @@ object Config {
 final case class AppConfig(database: DatabaseConfig,
                            pathToCredential: Path,
                            reportDestinationBucket: GcsBucketName,
-                           runtimeCheckerConfig: RuntimeCheckerConfig
+                           runtimeCheckerConfig: RuntimeCheckerConfig,
+                           prometheus: Prometheus
 )

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -37,7 +37,7 @@ object DbReader {
          SELECT DISTINCT c1.id, cloudContext, cloudProvider, runtimeName, rt.cloudService, c1.status, rt.zone, rt.region
             FROM CLUSTER AS c1
             INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
-            WHERE c1.status!="Deleted" AND c1.status!="Error" AND createdDate < now() - INTERVAL 1 HOUR
+            WHERE c1.status!="Deleted" AND c1.status!="Error" AND c1.createdDate < now() - INTERVAL 1 HOUR
         """.query[Runtime]
 
   val activeK8sClustersQuery =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -75,7 +75,7 @@ object ZombieMonitor {
   ): Resource[F, ZombieMonitorDeps[F]] =
     for {
       blockerBound <- Resource.eval(Semaphore[F](250))
-      metrics <- OpenTelemetryMetrics.resource(appConfig.pathToCredential, "leonardo-cron-jobs")
+      metrics <- OpenTelemetryMetrics.resource("leonardo-cron-jobs", appConfig.prometheus.port)
       runtimeCheckerDeps <- RuntimeCheckerDeps.init(appConfig.runtimeCheckerConfig, metrics, blockerBound)
       diskService <- GoogleDiskService.resource(appConfig.pathToCredential.toString, blockerBound)
       gkeService <- GKEService.resource(appConfig.pathToCredential, blockerBound)

--- a/zombie-monitor/src/test/resources/reference.conf
+++ b/zombie-monitor/src/test/resources/reference.conf
@@ -1,5 +1,13 @@
 path-to-credential = "path-to-credential"
 
+runtime-checker-config {
+  azure-app-registration {
+    client-id = ""
+    client-secret = ""
+    managed-app-tenant-id = ""
+  }
+}
+
 database {
   url = "jdbc:mysql://localhost:3311/leotestdb?createDatabaseIfNotExist=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&generateSimpleParameterMetadata=TRUE"
   user = "leonardo-test"

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.workbench.google2.{
   GoogleComputeService,
   GoogleDataprocService,
   GoogleStorageService,
-  InstanceName,
   RegionName,
   ZoneName
 }
@@ -33,6 +32,7 @@ import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.Generators.{arbDataprocRuntime, genRuntime}
 import org.broadinstitute.dsde.workbench.azure.AzureVmService
 import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
+import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalacheck.Arbitrary
 
 class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ConfigSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ConfigSpec.scala
@@ -1,8 +1,9 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import java.nio.file.Paths
+import org.broadinstitute.dsde.workbench.azure.{AzureAppRegistrationConfig, ClientId, ClientSecret, ManagedAppTenantId}
 
+import java.nio.file.Paths
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,8 +23,10 @@ class ConfigSpec extends AnyFlatSpec with Matchers {
       expectedReportDestinationBucket,
       RuntimeCheckerConfig(
         expectedPathToCredential,
-        expectedReportDestinationBucket
-      )
+        expectedReportDestinationBucket,
+        AzureAppRegistrationConfig(ClientId(""), ClientSecret(""), ManagedAppTenantId(""))
+      ),
+      Prometheus(9098)
     )
 
     config shouldBe Right(expectedConfig)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3289

This PR mostly brings in azure lib in https://github.com/broadinstitute/workbench-libs/pull/1005, and addressed a few gaps in checkers for Azure runtimes.

The only thing left is for checking "stopping" status since we don't currently support start/stop azure runtimes yet.


Tested resourceValidator locally
`sbt:resource-validator> run --dryRun --all`

Will keep an eye on things once it's merged to make sure all checks are working as expected