### PR TITLE
IA-3631 Attempt to fix some dependency conflict

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -4,7 +4,12 @@ import cats.syntax.all._
 import doobie.implicits.javasql.TimestampMeta
 import doobie.{Get, Meta, Read}
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{
+  KubernetesClusterId,
+  KubernetesClusterName,
+  NodepoolId,
+  NodepoolName
+}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
@@ -141,6 +146,49 @@ object DbReaderImplicits {
             }
           case CloudProvider.Gcp =>
             Nodepool(id, nodepoolName, k8sClusterName, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
+        }
+    }
+
+  implicit val k8sToScanRead: Read[K8sClusterToScan] =
+    Read[(Long, KubernetesClusterName, String, Location, CloudProvider)].map {
+      case (id, name, cloudContextDb, location, cloudProvider) =>
+        cloudProvider match {
+          case CloudProvider.Azure =>
+            AzureCloudContext.fromString(cloudContextDb) match {
+              case Left(value) =>
+                throw new RuntimeException(
+                  s"${value} is not valid azure cloud context"
+                )
+              case Right(value) =>
+                throw new RuntimeException(
+                  s"Azure is not supported yet" // TODO: IA-3623
+                )
+            }
+          case CloudProvider.Gcp =>
+            K8sClusterToScan(id, KubernetesClusterId(GoogleProject(cloudContextDb), location, name))
+        }
+    }
+
+  implicit val nodepoolToScanRead: Read[NodepoolToScan] =
+    Read[(Long, CloudProvider, String, Location, KubernetesClusterName, NodepoolName)].map {
+      case (id, cloudProvider, cloudContextDb, location, clusterName, nodepoolName) =>
+        cloudProvider match {
+          case CloudProvider.Azure =>
+            AzureCloudContext.fromString(cloudContextDb) match {
+              case Left(value) =>
+                throw new RuntimeException(
+                  s"${value} is not valid azure cloud context"
+                )
+              case Right(value) =>
+                throw new RuntimeException(
+                  s"Azure is not supported yet" // TODO: IA-3623
+                )
+            }
+          case CloudProvider.Gcp =>
+            NodepoolToScan(
+              id,
+              NodepoolId(KubernetesClusterId(GoogleProject(cloudContextDb), location, clusterName), nodepoolName)
+            )
         }
     }
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -55,22 +55,19 @@ final case class InitBucketToRemove(googleProject: GoogleProject, bucket: Option
 final case class K8sClusterToScan(id: Long, kubernetesClusterId: KubernetesClusterId)
 final case class NodepoolToScan(id: Long, nodepoolId: NodepoolId)
 
-final case class KubernetesClusterToRemove(id: Long, googleProject: GoogleProject)
+final case class KubernetesClusterToRemove(id: Long, cloudContext: CloudContext)
 
-final case class KubernetesCluster(clusterName: KubernetesClusterName,
-                                   googleProject: GoogleProject,
-                                   location: Location
-) {
-  override def toString: String = s"${googleProject}/${clusterName}"
+final case class KubernetesCluster(clusterName: KubernetesClusterName, cloudContext: CloudContext, location: Location) {
+  override def toString: String = s"${cloudContext.asStringWithProvider}/${clusterName}"
 }
 
 final case class Nodepool(nodepoolId: Long,
                           nodepoolName: NodepoolName,
                           clusterName: KubernetesClusterName,
-                          googleProject: GoogleProject,
+                          cloudContext: CloudContext,
                           location: Location
 ) {
-  override def toString: String = s"$googleProject/${nodepoolName.value}"
+  override def toString: String = s"${cloudContext.asStringWithProvider}/${nodepoolName.value}"
 }
 
 final case class DeleteNodepoolMeesage(nodepoolId: Long, googleProject: GoogleProject, traceId: Option[TraceId]) {

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -30,7 +30,7 @@ object DbReader {
   // TODO: Read the grace period (hardcoded to '1 HOUR' below) from config
   val kubernetesClustersToDeleteQuery =
     sql"""
-      SELECT kc.id, kc.cloudProvider, kc.cloudContext
+      SELECT kc.id, kc.cloudContext, kc.cloudProvider
       FROM KUBERNETES_CLUSTER kc
       WHERE
         kc.status != "DELETED" AND
@@ -62,7 +62,7 @@ object DbReader {
   // TODO: Read the grace period (hardcoded to '1 HOUR' below) from config
   val applessNodepoolQuery =
     sql"""
-        SELECT np.id, np.nodepoolName, kc.clusterName, kc.googleProject, kc.location
+        SELECT np.id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
         FROM NODEPOOL AS np
         INNER JOIN KUBERNETES_CLUSTER AS kc
         ON np.clusterId = kc.id

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -6,6 +6,8 @@ import doobie._
 import doobie.implicits._
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import com.broadinstitute.dsp.DbReaderImplicits.kubernetesClusterToRemoveRead
+import com.broadinstitute.dsp.DbReaderImplicits.nodepoolRead
 
 trait DbReader[F[_]] {
   def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove]
@@ -28,7 +30,7 @@ object DbReader {
   // TODO: Read the grace period (hardcoded to '1 HOUR' below) from config
   val kubernetesClustersToDeleteQuery =
     sql"""
-      SELECT kc.id, kc.googleProject
+      SELECT kc.id, kc.cloudProvider, kc.cloudContext
       FROM KUBERNETES_CLUSTER kc
       WHERE
         kc.status != "DELETED" AND

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
@@ -26,8 +26,14 @@ object NodepoolRemover {
           ctx <- ev.ask
           _ <-
             if (!isDryRun) {
-              val msg = DeleteNodepoolMeesage(n.nodepoolId, n.googleProject, Some(ctx))
-              deps.publisher.publishOne(msg)
+              n.cloudContext match {
+                case CloudContext.Gcp(value) =>
+                  val msg = DeleteNodepoolMeesage(n.nodepoolId, value, Some(ctx))
+                  deps.publisher.publishOne(msg)
+                case CloudContext.Azure(_) =>
+                  logger.warn("Azure is not supported yet") // TODO: IA-3623
+              }
+
             } else F.unit
         } yield Some(n)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val workbenchLibsHash = "3159fd9"
+  val workbenchLibsHash = "0e748a2"
   val workbenchGoogle2Version = s"0.24-${workbenchLibsHash}"
   val workbenchAzureVersion = s"0.1-${workbenchLibsHash}"
   val openTelemetryVersion = s"0.3-${workbenchLibsHash}"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -93,14 +93,14 @@ object DbReader {
       .query[Runtime]
 
   val deletedAndErroredKubernetesClusterQuery =
-    sql"""SELECT kc1.clusterName, googleProject, location
+    sql"""SELECT kc1.clusterName, cloudContext, location, cloudProvider
           FROM KUBERNETES_CLUSTER as kc1
           WHERE kc1.status="DELETED" OR kc1.status="ERROR"
           """
       .query[KubernetesCluster]
 
   val deletedAndErroredNodepoolQuery =
-    sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.googleProject, kc.location
+    sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
          WHERE np.status="DELETED" OR np.status="ERROR"

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -41,11 +41,11 @@ object DbReader {
         """.query[Runtime]
 
   val activeK8sClustersQuery =
-    sql"""select id, googleProject, location, clusterName from KUBERNETES_CLUSTER where status != "DELETED" and status != "ERROR";
+    sql"""select id, clusterName, cloudContext, location, cloudProvider from KUBERNETES_CLUSTER where status != "DELETED" and status != "ERROR";
         """.query[K8sClusterToScan]
 
   val activeNodepoolsQuery =
-    sql"""select np.id, cluster.googleProject, cluster.location, cluster.clusterName, np.nodepoolName from
+    sql"""select np.id, cluster.cloudProvider, cluster.cloudContext, cluster.location, cluster.clusterName, np.nodepoolName from
          	NODEPOOL AS np INNER JOIN KUBERNETES_CLUSTER AS cluster
          	on cluster.id = np.clusterId
          	where np.status != "DELETED" and np.status != "ERROR"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3631

resource-validator on dev is failing with 
```
stack_trace: "java.lang.NoClassDefFoundError: Could not initialize class com.azure.core.implementation.ReflectionUtilsApi
	at com.azure.core.http.rest.ResponseExceptionConstructorCache.locateExceptionConstructor(ResponseExceptionConstructorCache.java:38)
	at com.azure.core.http.rest.ResponseExceptionConstructorCache.lambda$get$0(ResponseExceptionConstructorCache.java:32)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(Unknown Source)
	at com.azure.core.http.rest.ResponseExceptionConstructorCache.get(ResponseExceptionConstructorCache.java:32)
	at com.azure.core.http.rest.RestProxy.instantiateUnexpectedException(RestProxy.java:395)
	at com.azure.core.http.rest.RestProxy.lambda$ensureExpectedStatus$1(RestProxy.java:351)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:113)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2398)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:169)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2194)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2068)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96)
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:55)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:127)
	at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onNext(FluxHide.java:137)
	at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:120)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.complete(MonoIgnoreThen.java:292)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.onNext(MonoIgnoreThen.java:187)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816)
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onNext(MonoFlatMap.java:249)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:151)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:127)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1816)
	at reactor.core.publisher.MonoCollect$CollectSubscriber.onComplete(MonoCollect.java:159)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1817)
	at reactor.core.publisher.FluxCallable.subscribe(FluxCallable.java:49)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at reactor.core.publisher.SerializedSubscriber.onNext(SerializedSubscriber.java:99)
	at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onNext(FluxRetryWhen.java:174)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
	at reactor.core.publisher.Operators$MonoInnerProducerBase.complete(Operators.java:2664)
	at reactor.core.publisher.MonoSingle$SingleSubscriber.onComplete(MonoSingle.java:180)
	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onComplete(MonoFlatMapMany.java:260)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onComplete(FluxMapFuseable.java:150)
	at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onComplete(FluxDoFinally.java:145)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onComplete(FluxMapFuseable.java:150)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1817)
	at reactor.core.publisher.MonoCollect$CollectSubscriber.onComplete(MonoCollect.java:159)
	at reactor.core.publisher.FluxHandle$HandleSubscriber.onComplete(FluxHandle.java:220)
	at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onComplete(FluxMap.java:269)
	at reactor.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:400)
	at reactor.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:419)
	at reactor.netty.channel.ChannelOperations.terminate(ChannelOperations.java:473)
	at reactor.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:703)
	at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:93)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
	at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1246)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1286)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:510)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:449)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:487)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:385)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```

This looks like some dependency conflicts among azure libraries. Try upgrading wb-libs which has higher version of azure libraries.

I can't seem to reproduce this locally running against dev DB, so this is just an attempt