### PR TITLE
IA-3858 ignore Azure nodepool, cluster

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -169,7 +169,7 @@ object DbReaderImplicits {
         }
     }
 
-  implicit val nodepoolToScanRead: Read[NodepoolToScan] =
+  implicit val nodepoolToScanRead: Read[Option[NodepoolToScan]] =
     Read[(Long, CloudProvider, String, Location, KubernetesClusterName, NodepoolName)].map {
       case (id, cloudProvider, cloudContextDb, location, clusterName, nodepoolName) =>
         cloudProvider match {
@@ -179,15 +179,16 @@ object DbReaderImplicits {
                 throw new RuntimeException(
                   s"${value} is not a valid azure cloud context"
                 )
-              case Right(_) =>
-                throw new RuntimeException(
-                  s"Azure is not supported yet" // TODO: IA-3623
-                )
+              case Right(x) =>
+                // Leonardo doesn't manage nodepool in the case of Azure. Hence ignoring the nodepool if it's Azure
+                none[NodepoolToScan]
             }
           case CloudProvider.Gcp =>
-            NodepoolToScan(
-              id,
-              NodepoolId(KubernetesClusterId(GoogleProject(cloudContextDb), location, clusterName), nodepoolName)
+            Some(
+              NodepoolToScan(
+                id,
+                NodepoolId(KubernetesClusterId(GoogleProject(cloudContextDb), location, clusterName), nodepoolName)
+              )
             )
         }
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -96,7 +96,7 @@ object DbReader {
   val deletedAndErroredKubernetesClusterQuery =
     sql"""SELECT kc1.clusterName, cloudContext, location, cloudProvider
           FROM KUBERNETES_CLUSTER as kc1
-          WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc.cloudProvider = "GCP"
+          WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc1.cloudProvider = "GCP"
           """
       .query[KubernetesCluster]
 
@@ -105,7 +105,7 @@ object DbReader {
     sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
-         WHERE np.status="DELETED" OR np.status="ERROR" AND kc.cloudProvider = "GCP"
+         WHERE (np.status="DELETED" OR np.status="ERROR") AND kc.cloudProvider = "GCP"
          """
       .query[Nodepool]
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -96,7 +96,7 @@ object DbReader {
   val deletedAndErroredKubernetesClusterQuery =
     sql"""SELECT kc1.clusterName, cloudContext, location, cloudProvider
           FROM KUBERNETES_CLUSTER as kc1
-          WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc.cloudProvider != "AZURE"
+          WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc.cloudProvider = "GCP"
           """
       .query[KubernetesCluster]
 
@@ -105,7 +105,7 @@ object DbReader {
     sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
-         WHERE np.status="DELETED" OR np.status="ERROR" AND kc.cloudProvider != "AZURE"
+         WHERE np.status="DELETED" OR np.status="ERROR" AND kc.cloudProvider = "GCP"
          """
       .query[Nodepool]
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -92,18 +92,20 @@ object DbReader {
              )"""
       .query[Runtime]
 
+  // Leonardo doesn't manage cluster for Azure. Hence excluding AKS clusters
   val deletedAndErroredKubernetesClusterQuery =
     sql"""SELECT kc1.clusterName, cloudContext, location, cloudProvider
           FROM KUBERNETES_CLUSTER as kc1
-          WHERE kc1.status="DELETED" OR kc1.status="ERROR"
+          WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc.cloudProvider != "AZURE"
           """
       .query[KubernetesCluster]
 
+  // Leonardo doesn't manage nodepool for Azure. Hence excluding Azure nodepools
   val deletedAndErroredNodepoolQuery =
     sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
-         WHERE np.status="DELETED" OR np.status="ERROR"
+         WHERE np.status="DELETED" OR np.status="ERROR" AND kc.cloudProvider != "AZURE"
          """
       .query[Nodepool]
 

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -49,7 +49,7 @@ object DbReader {
          	NODEPOOL AS np INNER JOIN KUBERNETES_CLUSTER AS cluster
          	on cluster.id = np.clusterId
          	where np.status != "DELETED" and np.status != "ERROR"
-         	""".query[NodepoolToScan]
+         	""".query[Option[NodepoolToScan]]
 
   def updateDiskStatusQuery(id: Int) =
     sql"""
@@ -125,7 +125,7 @@ object DbReader {
       markK8sClusterDeletedQuery(id.toInt).run.transact(xa).void
 
     override def getk8sNodepoolsToDeleteCandidate: Stream[F, NodepoolToScan] =
-      activeNodepoolsQuery.stream.transact(xa)
+      activeNodepoolsQuery.stream.unNone.transact(xa)
 
     override def markNodepoolAndAppDeleted(nodepoolId: Long): F[Unit] = {
       val res = for {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3858

For zombie monitor, update the DB reader to ignore Azure nodepool for now.
For resource-validator, update the SQL query to exclude Azure from the start.