### PR TITLE
[IA-3883] Detect apps stuck in creating or deleting states

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ docker run \
   -instances=<mysql instance you'd like to connect> -credential_file=/config
 ```
 
-## Set up configuration file
+## Set up configuration files
 Copy `application.conf.example` under each project in dir `[project]/src/main/resources` as `application.conf`. Replace values appropriately.
 i.e. the `leonardo-pubsub.google-project`  will need to be one that the user you are configured as will have access to.
+Copy `reference.conf.example` under each project in dir `[project]/src/main/resources` as `reference.conf`. Replace values appropriately.
 
+Do not commit the `application.conf` or `reference.conf` as they are used to run the jobs locally only.
 
 ## Run a job
 ```

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -148,8 +148,6 @@ final case class ServiceData(version: Option[String]) {
 final case class Prometheus(port: Int)
 
 final case class StorageAccountName(value: String) extends AnyVal
-final case class AzureStagingBucket(storageAccount: StorageAccountName,
-                                    storageContainerName: org.broadinstitute.dsde.workbench.azure.ContainerName
-) {
-  def asString: String = s"${storageAccount.value}/${storageContainerName.value}"
+final case class AzureStagingBucket(storageContainerName: org.broadinstitute.dsde.workbench.azure.ContainerName) {
+  def asString: String = s"${storageContainerName.value}"
 }

--- a/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
@@ -12,7 +12,7 @@ import org.scalatest.Tag
 import DbReaderImplicits._
 import java.time.Instant
 
-object DBTestHelper {
+object DbTestHelper {
   implicit val cloudServicePut: Put[CloudService] = Put[String].contramap(cloudService => cloudService.asString)
   val zoneName = ZoneName("us-central1-a")
   val regionName = RegionName("us-central1")
@@ -46,7 +46,7 @@ object DBTestHelper {
     xa: HikariTransactor[IO]
   ): IO[Long] =
     sql"""INSERT INTO KUBERNETES_CLUSTER
-         (googleProject, clusterName, location, status, creator, createdDate, destroyedDate, dateAccessed, loadBalancerIp, networkName, subNetworkName, subNetworkIpRange, region, apiServerIp, ingressChart)
+         (cloudContext, clusterName, location, status, creator, createdDate, destroyedDate, dateAccessed, loadBalancerIp, networkName, subNetworkName, subNetworkIpRange, region, apiServerIp, ingressChart)
          VALUES (${clusterId.project}, ${clusterId.clusterName}, ${clusterId.location}, ${status}, "fake@broadinstitute.org", now(), now(), now(), "0.0.0.1", "network", "subnetwork", "0.0.0.1/20", ${regionName}, "35.202.56.6", "stable/nginx-ingress-1.41.3")
          """.update.withUniqueGeneratedKeys[Long]("id").transact(xa)
 

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -18,9 +18,9 @@ object Generators {
     status <- possibleStatuses.fold(Gen.oneOf("Running", "Creating", "Deleted", "Error"))(s => Gen.oneOf(s.toList))
   } yield cloudService match {
     case CloudService.Dataproc =>
-      Runtime.Dataproc(id, project, runtimeName, cloudService, status, DBTestHelper.regionName)
+      Runtime.Dataproc(id, project, runtimeName, cloudService, status, DbTestHelper.regionName)
     case CloudService.Gce =>
-      Runtime.Gce(id, project, runtimeName, cloudService, status, DBTestHelper.zoneName)
+      Runtime.Gce(id, project, runtimeName, cloudService, status, DbTestHelper.zoneName)
     case CloudService.AzureVM =>
       Runtime.AzureVM(id, CloudContext.Azure(azureCloudContext), runtimeName, cloudService, status)
   }
@@ -29,7 +29,7 @@ object Generators {
     project <- genGoogleProject
     runtimeName <- Gen.uuid.map(_.toString)
     status <- Gen.oneOf("Running", "Creating", "Deleted", "Error")
-  } yield Runtime.Dataproc(id, project, runtimeName, CloudService.Dataproc, status, DBTestHelper.regionName)
+  } yield Runtime.Dataproc(id, project, runtimeName, CloudService.Dataproc, status, DbTestHelper.regionName)
   val genDisk: Gen[Disk] = for {
     id <- Gen.chooseNum(0, 100)
     project <- genGoogleProject

--- a/janitor/src/main/resources/reference.conf
+++ b/janitor/src/main/resources/reference.conf
@@ -14,15 +14,15 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
-report-destination-bucket = "liz-baldo-dev-testing"
+report-destination-bucket = "replace-me"
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 
   azure-app-registration {
-   client-id = "bce2f808-21ea-478f-b4f6-91896d1424aa"
-   client-secret = "MVs7Q~D4xNQ3s3Y1H8VoJuFhEtwwFrBvVCJnS"
-   managed-app-tenant-id = "fad90753-2022-4456-9b0a-c7e5b934e408"
+    client-id = ${LEONARDO_AZURE_APP_CLIENT_ID}
+    client-secret = ${LEONARDO_AZURE_APP_CLIENT_SECRET}
+    managed-app-tenant-id = ${LEONARDO_AZURE_APP_TENANT_ID}
   }
 }

--- a/janitor/src/main/resources/reference.conf.example
+++ b/janitor/src/main/resources/reference.conf.example
@@ -14,15 +14,17 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
-report-destination-bucket = "liz-baldo-dev-testing"
+report-destination-bucket = "replace me" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket
+
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 
+# Look into the azure app-registration section from the leonardo.conf file in the leonardo repo
   azure-app-registration {
-   client-id = "bce2f808-21ea-478f-b4f6-91896d1424aa"
-   client-secret = "MVs7Q~D4xNQ3s3Y1H8VoJuFhEtwwFrBvVCJnS"
-   managed-app-tenant-id = "fad90753-2022-4456-9b0a-c7e5b934e408"
+   client-id = "replace me"
+   client-secret = "replace me"
+   managed-app-tenant-id = "replace me"
   }
 }

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -5,9 +5,12 @@ import cats.effect.Async
 import com.broadinstitute.dsp.DbReaderImplicits.{cloudProviderMeta, kubernetesClusterToRemoveRead, nodepoolRead}
 import doobie._
 import doobie.implicits._
+import doobie.implicits.javasql._ // Mapping for temporal types require a specific import https://github.com/tpolecat/doobie/releases/tag/v0.8.8
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ContainerName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+
+import java.sql.{SQLDataException, Timestamp}
 
 trait DbReader[F[_]] {
   def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove]
@@ -170,7 +173,7 @@ object BucketToRemove {
   }
 }
 
-final case class AppToReport(id: Long, name: String, status: String, createdDate: String) {
+final case class AppToReport(id: Long, name: String, status: String, createdDate: Timestamp) {
   override def toString: String =
     s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
 }

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -170,7 +170,7 @@ object BucketToRemove {
   }
 }
 
-final case class AppToReport(id: Long, name: Long, status: String, createdDate: String) {
+final case class AppToReport(id: Long, name: AppName, status: String, createdDate: String) {
   override def toString: String =
     s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
 }

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -170,7 +170,7 @@ object BucketToRemove {
   }
 }
 
-final case class AppToReport(id: Long, name: AppName, status: String, createdDate: String) {
+final case class AppToReport(id: Long, name: String, status: String, createdDate: String) {
   override def toString: String =
     s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
 }

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -130,17 +130,17 @@ object DbReader {
    * We want to flag apps that have been stuck in creating for more than 2 hours and report them to the user
    * to avoid hidden costs. Since apps cannot be deleted while creating, there is not much more we can do other
    * than report.
-   * We sinilarily want to flag apps that have been stuck in deleting for more than 1 hour.
+   * We similarly want to flag apps that have been stuck in deleting for more than 1 hour.
    *
-   * Note that there are no `Creating` status for apps, only `STARTING`, `PRESTARTING`, `PRECREATING`, or `PROVISIONING`
+   * Note that there are no `Creating` status for apps, it corresponds to `PRECREATING`, or `PROVISIONING`
    */
   val appStuckQuery =
     sql"""
         SELECT id, appName, status, createdDate
         FROM APP
         WHERE
-          (status in ("STARTING", "PRESTARTING", "PRECREATING", "PROVISIONING") AND createdDate < now() - INTERVAL 2 HOUR) OR
-          (status="DELETING" ANDvcreatedDate < now() - INTERVAL 1 HOUR);
+          (status in ("PRECREATING", "PROVISIONING") AND createdDate < now() - INTERVAL 2 HOUR) OR
+          (status="DELETING" AND createdDate < now() - INTERVAL 1 HOUR);
         """
       .query[AppToReport]
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -13,6 +13,7 @@ trait DbReader[F[_]] {
   def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove]
   def getNodepoolsToDelete: Stream[F, Nodepool]
   def getStagingBucketsToDelete: Stream[F, BucketToRemove]
+  def getStuckAppToReport: Stream[F, AppToReport]
 }
 
 object DbReader {
@@ -125,6 +126,25 @@ object DbReader {
         """
       .query[BucketToRemove]
 
+  /**
+   * We want to flag apps that have been stuck in creating for more than 2 hours and report them to the user
+   * to avoid hidden costs. Since apps cannot be deleted while creating, there is not much more we can do other
+   * than report.
+   * We sinilarily want to flag apps that have been stuck in deleting for more than 1 hour.
+   *
+   * Note that there are no `Creating` status for apps, only `STARTING`, `PRESTARTING`, `PRECREATING`, or `PROVISIONING`
+   */
+  val appStuckQuery =
+    sql"""
+        SELECT id, appName, status, createdDate
+        FROM APP
+        WHERE
+          (status in ("STARTING", "PRESTARTING", "PRECREATING", "PROVISIONING") AND createdDate < now() - INTERVAL 2 HOUR) OR
+          (status="DELETING" ANDvcreatedDate < now() - INTERVAL 1 HOUR);
+        """
+      .query[AppToReport]
+
+
   def impl[F[_]](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
     override def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove] =
       kubernetesClustersToDeleteQuery.stream.transact(xa)
@@ -134,6 +154,9 @@ object DbReader {
 
     override def getStagingBucketsToDelete: Stream[F, BucketToRemove] =
       stagingBucketsToDeleteQuery.stream.transact(xa)
+
+    override def getStuckAppToReport: Stream[F, AppToReport] =
+      appStuckQuery.stream.transact(xa)
   }
 }
 
@@ -147,3 +170,9 @@ object BucketToRemove {
     override def toString: String = s"${azureCloudContext.asString},${bucket.getOrElse("null")}"
   }
 }
+
+final case class AppToReport(id: Long, name: Long, status: String, createdDate: String){
+  override def toString: String = s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
+}
+
+

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -144,7 +144,6 @@ object DbReader {
         """
       .query[AppToReport]
 
-
   def impl[F[_]](xa: Transactor[F])(implicit F: Async[F]): DbReader[F] = new DbReader[F] {
     override def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove] =
       kubernetesClustersToDeleteQuery.stream.transact(xa)
@@ -171,8 +170,7 @@ object BucketToRemove {
   }
 }
 
-final case class AppToReport(id: Long, name: Long, status: String, createdDate: String){
-  override def toString: String = s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
+final case class AppToReport(id: Long, name: Long, status: String, createdDate: String) {
+  override def toString: String =
+    s"App id:${id}, App name:${name}, App status:${status}, App creation time: ${createdDate}"
 }
-
-

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -10,7 +10,7 @@ import fs2.Stream
 import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, ContainerName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
-import java.sql.{SQLDataException, Timestamp}
+import java.sql.Timestamp
 
 trait DbReader[F[_]] {
   def getKubernetesClustersToDelete: Stream[F, KubernetesClusterToRemove]

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Janitor.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Janitor.scala
@@ -54,7 +54,8 @@ object Janitor {
 
       reportStuckApps =
         if (shouldCheckAll || shouldCheckStuckAppsToBeReported)
-          Stream.eval(StuckAppReporter.impl(deps.dbReader).run(isDryRun))
+          Stream.eval(StuckAppReporter.impl(deps.dbReader, deps.leoPublisherDeps).run(isDryRun))
+        else Stream.empty
 
       processes = Stream(removeKubernetesClusters, removeNodepools, removeStagingBuckets, reportStuckApps).covary[F]
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/Main.scala
@@ -21,18 +21,22 @@ object Main
       Opts.flag("checkNodepoolsToRemove", "check nodepools that should be removed").orFalse
     val shouldCheckStagingBucketsToBeRemoved =
       Opts.flag("checkStagingBucketsToRemove", "check staging buckets that should be removed").orFalse
+    val shouldCheckStuckAppsToBeReported =
+      Opts.flag("checkStuckAppsToBeReported", "check apps that are stuck in creating or deleting status").orFalse
 
     (enableDryRun,
      shouldCheckAll,
      shouldCheckKubernetesClustersToBeRemoved,
      shouldCheckNodepoolsToBeRemoved,
-     shouldCheckStagingBucketsToBeRemoved
+     shouldCheckStagingBucketsToBeRemoved,
+     shouldCheckStuckAppsToBeReported
     ).mapN {
       (dryRun,
        checkAll,
        shouldCheckKubernetesClustersToBeRemoved,
        shouldCheckNodepoolsToBeRemoved,
-       shouldCheckStagingBucketsToBeRemoved
+       shouldCheckStagingBucketsToBeRemoved,
+       shouldCheckStuckAppsToBeReported
       ) =>
         Janitor
           .run[IO](
@@ -40,7 +44,8 @@ object Main
             shouldCheckAll = checkAll,
             shouldCheckKubernetesClustersToBeRemoved = shouldCheckKubernetesClustersToBeRemoved,
             shouldCheckNodepoolsToBeRemoved = shouldCheckNodepoolsToBeRemoved,
-            shouldCheckStagingBucketsToBeRemoved = shouldCheckStagingBucketsToBeRemoved
+            shouldCheckStagingBucketsToBeRemoved = shouldCheckStagingBucketsToBeRemoved,
+            shouldCheckStuckAppsToBeReported = shouldCheckStuckAppsToBeReported
           )
           .compile
           .drain

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
@@ -7,6 +7,9 @@ import cats.implicits._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
 object StuckAppReporter {
   def impl[F[_]](
     dbReader: DbReader[F],
@@ -20,7 +23,9 @@ object StuckAppReporter {
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 
       override def resourceToScan: fs2.Stream[F, AppToReport] =
-        fs2.Stream.eval(F.pure(AppToReport(10L, "dummyapp", "stuck", "now"))) // dbReader.getStuckAppToReport
+        fs2.Stream.eval(
+          F.pure(AppToReport(10L, "dummyapp", "stuck", Timestamp.valueOf(LocalDateTime.now())))
+        ) // dbReader.getStuckAppToReport
 
       override def checkResource(a: AppToReport, isDryRun: Boolean)(implicit
         ev: Ask[F, TraceId]

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
@@ -3,11 +3,10 @@ package janitor
 
 import cats.effect.Concurrent
 import cats.mtl.Ask
-import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
-class StuckAppReporter {
+object StuckAppReporter {
   def impl[F[_]](
     dbReader: DbReader[F],
     deps: LeoPublisherDeps[F]

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
@@ -19,7 +19,8 @@ object StuckAppReporter {
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 
-      override def resourceToScan: fs2.Stream[F, AppToReport] = dbReader.getStuckAppToReport
+      override def resourceToScan: fs2.Stream[F, AppToReport] =
+        fs2.Stream.eval(F.pure(AppToReport(10L, "dummyapp", "stuck", "now"))) // dbReader.getStuckAppToReport
 
       override def checkResource(a: AppToReport, isDryRun: Boolean)(implicit
         ev: Ask[F, TraceId]

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
@@ -3,6 +3,7 @@ package janitor
 
 import cats.effect.Concurrent
 import cats.mtl.Ask
+import cats.implicits._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
@@ -13,14 +14,20 @@ object StuckAppReporter {
   )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, AppToReport] =
     new CheckRunner[F, AppToReport] {
       override def appName: String = janitor.appName
+
       override def configs = CheckRunnerConfigs(s"alert-apps-stuck-in-creating-deleting-status", shouldAlert = false)
+
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+
       override def resourceToScan: fs2.Stream[F, AppToReport] = dbReader.getStuckAppToReport
+
       override def checkResource(a: AppToReport, isDryRun: Boolean)(implicit
         ev: Ask[F, TraceId]
       ): F[Option[AppToReport]] =
-        if (!isDryRun) {
-          F.pure(Some(a))
-        } else F.pure(None)
+        for {
+          log <-
+            if (!isDryRun) logger.info("Reporting apps stuck in Creating or Deleting status").as(Some(a))
+            else logger.info("Dry run").as(None)
+        } yield log
     }
 }

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/StuckAppReporter.scala
@@ -1,0 +1,27 @@
+package com.broadinstitute.dsp
+package janitor
+
+import cats.effect.Concurrent
+import cats.mtl.Ask
+import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.Logger
+
+class StuckAppReporter {
+  def impl[F[_]](
+    dbReader: DbReader[F],
+    deps: LeoPublisherDeps[F]
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, AppToReport] =
+    new CheckRunner[F, AppToReport] {
+      override def appName: String = janitor.appName
+      override def configs = CheckRunnerConfigs(s"alert-apps-stuck-in-creating-deleting-status", shouldAlert = false)
+      override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
+      override def resourceToScan: fs2.Stream[F, AppToReport] = dbReader.getStuckAppToReport
+      override def checkResource(a: AppToReport, isDryRun: Boolean)(implicit
+        ev: Ask[F, TraceId]
+      ): F[Option[AppToReport]] =
+        if (!isDryRun) {
+          F.pure(Some(a))
+        } else F.pure(None)
+    }
+}

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import com.broadinstitute.dsp.DBTestHelper._
+import com.broadinstitute.dsp.DbTestHelper._
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
@@ -27,4 +27,8 @@ final class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with I
   it should "build stagingBucketsToDeleteQuery properly" taggedAs DbTest in {
     check(DbReader.stagingBucketsToDeleteQuery)
   }
+
+  it should "build appStuckQuery properly" taggedAs DbTest in {
+    check(DbReader.appStuckQuery)
+  }
 }

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
@@ -1,0 +1,105 @@
+package com.broadinstitute.dsp
+package janitor
+
+import com.broadinstitute.dsp.DBTestHelper.{
+  insertApp,
+  insertDisk,
+  insertK8sCluster,
+  insertNamespace,
+  insertNodepool,
+  transactorResource,
+  yoloTransactor
+}
+import com.broadinstitute.dsp.Generators._
+import doobie.scalatest.IOChecker
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
+import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
+import org.scalatest.flatspec.AnyFlatSpec
+import cats.effect.unsafe.implicits.global
+import java.time.Instant
+
+/**
+ * Not running these tests in CI yet since we'll need to set up mysql container and Leonardo tables in CI. Punt for now
+ * For running these tests locally, you can
+ *   - Start leonardo mysql container locally
+ *   - Run a Leonardo database unit test (e.g. ClusterComponentSpec)
+ *   - Run this spec
+ */
+class DbReaderGetAppStuckToReportSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+  implicit val config = ConfigSpec.config.database
+  val transactor = yoloTransactor
+
+  val now = Instant.now()
+  val gracePeriod_deleting = 3600 // in seconds
+  val gracePeriod_creating = 7200 // in seconds
+
+  it should "detect for reporting: App in DELETING or CREATING status BEYOND grace period" taggedAs DbTest in {
+    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+      val res = transactorResource.use { implicit xa =>
+        val dbReader = DbReader.impl(xa)
+
+        for {
+          diskId <- insertDisk(disk)
+          clusterId <- insertK8sCluster(cluster, "RUNNING")
+          _ <- insertNodepool(clusterId, "default-np", true)
+          nodepoolId <- insertNodepool(clusterId, "np", false, "RUNNING")
+          namespaceId <- insertNamespace(clusterId, NamespaceName("ns"))
+          appId_deleting <- insertApp(nodepoolId,
+                                      namespaceId,
+                                      "app_deleting",
+                                      diskId,
+                                      "DELETING",
+                                      now.minusSeconds(gracePeriod_deleting + 100),
+                                      now.minusSeconds(gracePeriod_deleting + 200)
+          )
+          appId_creating <- insertApp(nodepoolId,
+                                      namespaceId,
+                                      "app_creating",
+                                      diskId,
+                                      "PROVISIONING",
+                                      now.minusSeconds(gracePeriod_creating + 100),
+                                      now.minusSeconds(gracePeriod_creating + 200)
+          )
+
+          appsToReport <- dbReader.getStuckAppToReport.compile.toList
+        } yield appsToReport.map(_.id) shouldBe List(appId_deleting, appId_creating)
+      }
+      res.unsafeRunSync()
+    }
+  }
+
+  it should "not detect for reporting: App in DELETING or CREATING status WITHIN grace period" taggedAs DbTest in {
+    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+      val res = transactorResource.use { implicit xa =>
+        val dbReader = DbReader.impl(xa)
+
+        for {
+          diskId <- insertDisk(disk)
+          clusterId <- insertK8sCluster(cluster, "RUNNING")
+          _ <- insertNodepool(clusterId, "default-np", true)
+          nodepoolId <- insertNodepool(clusterId, "np", false, "RUNNING")
+          namespaceId <- insertNamespace(clusterId, NamespaceName("ns"))
+          _ <- insertApp(nodepoolId,
+                         namespaceId,
+                         "app_deleting",
+                         diskId,
+                         "DELETING",
+                         now.minusSeconds(gracePeriod_deleting - 100),
+                         now.minusSeconds(gracePeriod_deleting + 200)
+          )
+          _ <- insertApp(nodepoolId,
+                         namespaceId,
+                         "app_creating",
+                         diskId,
+                         "PROVISIONING",
+                         now.minusSeconds(gracePeriod_creating - 100),
+                         now.minusSeconds(gracePeriod_creating + 200)
+          )
+
+          appsToReport <- dbReader.getStuckAppToReport.compile.toList
+        } yield appsToReport.map(_.id) shouldBe List.empty
+      }
+      res.unsafeRunSync()
+    }
+  }
+}

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import com.broadinstitute.dsp.DBTestHelper.{
+import com.broadinstitute.dsp.DbTestHelper.{
   insertApp,
   insertDisk,
   insertK8sCluster,

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 package janitor
 
 import cats.effect.unsafe.implicits.global
-import com.broadinstitute.dsp.DBTestHelper._
+import com.broadinstitute.dsp.DbTestHelper._
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
-import com.broadinstitute.dsp.DBTestHelper.{
+import com.broadinstitute.dsp.DbTestHelper.{
   insertApp,
   insertDisk,
   insertK8sCluster,
@@ -26,7 +26,7 @@ import java.time.Instant
  *   - Run a Leonardo database unit test (e.g. ClusterComponentSpec)
  *   - Run this spec
  */
-class DBReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
+class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/StuckAppReporterSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/StuckAppReporterSpec.scala
@@ -13,6 +13,9 @@ import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsI
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
 
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
 final class StuckAppReporterSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "Only log apps detected to be stuck in deleting or creating status when dryRun is False" in {
     forAll { (dryRun: Boolean) =>
@@ -20,7 +23,7 @@ final class StuckAppReporterSpec extends AnyFlatSpec with CronJobsTestSuite {
         10L,
         "test_app_name",
         "DELETING",
-        "test_creation_date"
+        Timestamp.valueOf(LocalDateTime.now())
       )
       val dbReader = new FakeDbReader {
         override def getStuckAppToReport: Stream[IO, AppToReport] =

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/StuckAppReporterSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/StuckAppReporterSpec.scala
@@ -1,0 +1,50 @@
+package com.broadinstitute.dsp
+package janitor
+
+import cats.effect.IO
+import fs2.Stream
+import org.broadinstitute.dsde.workbench.google2.{GoogleBillingService, GooglePublisher}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  FakeGoogleBillingInterpreter,
+  FakeGooglePublisher,
+  FakeGoogleStorageInterpreter
+}
+import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
+import org.scalatest.flatspec.AnyFlatSpec
+import cats.effect.unsafe.implicits.global
+
+final class StuckAppReporterSpec extends AnyFlatSpec with CronJobsTestSuite {
+  it should "Only log apps detected to be stuck in deleting or creating status when dryRun is False" in {
+    forAll { (dryRun: Boolean) =>
+      val stuckApp = AppToReport(
+        10L,
+        "test_app_name",
+        "DELETING",
+        "test_creation_date"
+      )
+      val dbReader = new FakeDbReader {
+        override def getStuckAppToReport: Stream[IO, AppToReport] =
+          Stream.emit(stuckApp)
+      }
+
+      val publisher = new FakeGooglePublisher {}
+      val deps = initDeps(publisher)
+      val checker = StuckAppReporter.impl(dbReader, deps)
+      val res = checker.checkResource(stuckApp, dryRun)
+
+      if (dryRun) res.unsafeRunSync() shouldBe None
+      else res.unsafeRunSync() shouldBe Some(stuckApp)
+    }
+  }
+
+  private def initDeps(publisher: GooglePublisher[IO],
+                       billingService: GoogleBillingService[IO] = FakeGoogleBillingInterpreter
+  ): LeoPublisherDeps[IO] = {
+    val checkRunnerDeps =
+      CheckRunnerDeps(ConfigSpec.config.reportDestinationBucket,
+                      FakeGoogleStorageInterpreter,
+                      FakeOpenTelemetryMetricsInterpreter
+      )
+    new LeoPublisherDeps[IO](publisher, checkRunnerDeps, billingService)
+  }
+}

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/mocks.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/mocks.scala
@@ -8,4 +8,5 @@ class FakeDbReader extends DbReader[IO] {
   override def getKubernetesClustersToDelete: Stream[IO, KubernetesClusterToRemove] = Stream.empty
   override def getNodepoolsToDelete: Stream[IO, Nodepool] = Stream.empty
   override def getStagingBucketsToDelete: Stream[IO, BucketToRemove] = Stream.empty
+  override def getStuckAppToReport: Stream[IO, AppToReport] = Stream.empty
 }

--- a/resource-validator/src/main/resources/reference.conf.example
+++ b/resource-validator/src/main/resources/reference.conf.example
@@ -14,15 +14,17 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
-report-destination-bucket = "liz-baldo-dev-testing"
+report-destination-bucket = "replace me" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket
+
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 
+# Look into the azure app-registration section from the leonardo.conf file in the leonardo repo
   azure-app-registration {
-   client-id = "bce2f808-21ea-478f-b4f6-91896d1424aa"
-   client-secret = "MVs7Q~D4xNQ3s3Y1H8VoJuFhEtwwFrBvVCJnS"
-   managed-app-tenant-id = "fad90753-2022-4456-9b0a-c7e5b934e408"
+   client-id = "replace me"
+   client-secret = "replace me"
+   managed-app-tenant-id = "replace me"
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import com.broadinstitute.dsp.DBTestHelper._
+import com.broadinstitute.dsp.DbTestHelper._
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -1,7 +1,7 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
-import com.broadinstitute.dsp.DBTestHelper.{insertK8sCluster, _}
+import com.broadinstitute.dsp.DbTestHelper.{insertK8sCluster, _}
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -2,7 +2,7 @@ package com.broadinstitute.dsp
 package resourceValidator
 
 import cats.effect.unsafe.implicits.global
-import com.broadinstitute.dsp.DBTestHelper.{
+import com.broadinstitute.dsp.DbTestHelper.{
   getNodepoolName,
   insertK8sCluster,
   insertNodepool,

--- a/zombie-monitor/src/main/resources/reference.conf.example
+++ b/zombie-monitor/src/main/resources/reference.conf.example
@@ -14,15 +14,17 @@ leonardo-pubsub {
   topic-name = "leonardo-pubsub"
 }
 
-report-destination-bucket = "liz-baldo-dev-testing"
+report-destination-bucket = "replace me" # if you're using leonardo's dev SA for local testing, make sure to give leonardo's dev SA write permission to this bucket
+
 
 runtime-checker-config {
   path-to-credential = ${path-to-credential}
   report-destination-bucket = ${report-destination-bucket}
 
+# Look into the azure app-registration section from the leonardo.conf file in the leonardo repo
   azure-app-registration {
-   client-id = "bce2f808-21ea-478f-b4f6-91896d1424aa"
-   client-secret = "MVs7Q~D4xNQ3s3Y1H8VoJuFhEtwwFrBvVCJnS"
-   managed-app-tenant-id = "fad90753-2022-4456-9b0a-c7e5b934e408"
+   client-id = "replace me"
+   client-secret = "replace me"
+   managed-app-tenant-id = "replace me"
   }
 }

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -3,7 +3,7 @@ package zombieMonitor
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import com.broadinstitute.dsp.DBTestHelper._
+import com.broadinstitute.dsp.DbTestHelper._
 import com.broadinstitute.dsp.Generators._
 import doobie.implicits._
 import doobie.scalatest.IOChecker


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3883

This PR does the following:
- Adds a query in the DbReader to query apps stuck in `creating` for more than 2 hours, or stuck in `deleting` for more than one hour (only one query for both cases for now)
- Reports  the result of that query in the google cloud logs

I was able to successfully run the query against my cloned instance of the leo DB, but would like some eyes on the logging front, happy to pair review!

Note that all unit tests, including the ones making use of the local leo DB are passing locally :)