### PR TITLE
[IA-3623] Update cron jobs to support AKS apps

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -4,12 +4,7 @@ import cats.syntax.all._
 import doobie.implicits.javasql.TimestampMeta
 import doobie.{Get, Meta, Read}
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{
-  KubernetesClusterId,
-  KubernetesClusterName,
-  NodepoolId,
-  NodepoolName
-}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
@@ -114,8 +109,8 @@ object DbReaderImplicits {
     }
 
   implicit val kubernetesClusterRead: Read[KubernetesCluster] =
-    Read[(KubernetesClusterName, String, Location, CloudProvider)].map {
-      case (name, cloudContextDb, location, cloudProvider) =>
+    Read[(Long, KubernetesClusterName, String, Location, CloudProvider)].map {
+      case (id, name, cloudContextDb, location, cloudProvider) =>
         cloudProvider match {
           case CloudProvider.Azure =>
             AzureCloudContext.fromString(cloudContextDb) match {
@@ -124,10 +119,10 @@ object DbReaderImplicits {
                   s"${value} is not valid azure cloud context"
                 )
               case Right(value) =>
-                KubernetesCluster(name, CloudContext.Azure(value), location)
+                KubernetesCluster(id, name, CloudContext.Azure(value), location)
             }
           case CloudProvider.Gcp =>
-            KubernetesCluster(name, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
+            KubernetesCluster(id, name, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
         }
     }
 
@@ -146,50 +141,6 @@ object DbReaderImplicits {
             }
           case CloudProvider.Gcp =>
             Nodepool(id, nodepoolName, k8sClusterName, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
-        }
-    }
-
-  implicit val k8sToScanRead: Read[K8sClusterToScan] =
-    Read[(Long, KubernetesClusterName, String, Location, CloudProvider)].map {
-      case (id, name, cloudContextDb, location, cloudProvider) =>
-        cloudProvider match {
-          case CloudProvider.Azure =>
-            AzureCloudContext.fromString(cloudContextDb) match {
-              case Left(value) =>
-                throw new RuntimeException(
-                  s"${value} is not valid azure cloud context"
-                )
-              case Right(_) =>
-                throw new RuntimeException(
-                  s"Azure is not supported yet" // TODO: IA-3623
-                )
-            }
-          case CloudProvider.Gcp =>
-            K8sClusterToScan(id, KubernetesClusterId(GoogleProject(cloudContextDb), location, name))
-        }
-    }
-
-  implicit val nodepoolToScanRead: Read[Option[NodepoolToScan]] =
-    Read[(Long, CloudProvider, String, Location, KubernetesClusterName, NodepoolName)].map {
-      case (id, cloudProvider, cloudContextDb, location, clusterName, nodepoolName) =>
-        cloudProvider match {
-          case CloudProvider.Azure =>
-            AzureCloudContext.fromString(cloudContextDb) match {
-              case Left(value) =>
-                throw new RuntimeException(
-                  s"${value} is not a valid azure cloud context"
-                )
-              case Right(x) =>
-                // Leonardo doesn't manage nodepool in the case of Azure. Hence ignoring the nodepool if it's Azure
-                none[NodepoolToScan]
-            }
-          case CloudProvider.Gcp =>
-            Some(
-              NodepoolToScan(
-                id,
-                NodepoolId(KubernetesClusterId(GoogleProject(cloudContextDb), location, clusterName), nodepoolName)
-              )
-            )
         }
     }
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/checkerDeps.scala
@@ -3,7 +3,7 @@ package com.broadinstitute.dsp
 import cats.Parallel
 import cats.effect.std.Semaphore
 import cats.effect.{Async, Resource}
-import org.broadinstitute.dsde.workbench.azure.{AzureAppRegistrationConfig, AzureVmService}
+import org.broadinstitute.dsde.workbench.azure.{AzureAppRegistrationConfig, AzureContainerService, AzureVmService}
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.google2.{
   GKEService,
@@ -120,7 +120,10 @@ final case class RuntimeCheckerDeps[F[_]](computeService: GoogleComputeService[F
                                           azureVmService: AzureVmService[F]
 )
 
-final case class KubernetesClusterCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F], gkeService: GKEService[F])
+final case class KubernetesClusterCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F],
+                                                    gkeService: GKEService[F],
+                                                    aksService: AzureContainerService[F]
+)
 
 final case class NodepoolCheckerDeps[F[_]](checkRunnerDeps: CheckRunnerDeps[F],
                                            gkeService: GKEService[F],

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -47,8 +47,6 @@ final case class InitBucketToRemove(googleProject: GoogleProject, bucket: Option
   override def toString: String = s"${googleProject.value},${bucket.getOrElse("null")}"
 }
 
-//final case class K8sClusterToScan(id: Long, kubernetesClusterId: KubernetesClusterId)
-//final case class NodepoolToScan(id: Long, nodepoolId: NodepoolId)
 final case class KubernetesClusterToRemove(id: Long, cloudContext: CloudContext)
 
 final case class KubernetesCluster(id: Long,

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -3,16 +3,11 @@ package com.broadinstitute.dsp
 import ca.mrvisser.sealerate
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterName, NodepoolName}
+import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}
 import org.broadinstitute.dsde.workbench.google2.{DiskName, Location, ZoneName}
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{
-  KubernetesClusterId,
-  KubernetesClusterName,
-  NodepoolId,
-  NodepoolName
-}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
-import org.broadinstitute.dsde.workbench.google2.JsonCodec.{googleProjectEncoder, traceIdEncoder}
 
 sealed abstract class CloudService extends Product with Serializable {
   def asString: String
@@ -52,11 +47,15 @@ final case class InitBucketToRemove(googleProject: GoogleProject, bucket: Option
   override def toString: String = s"${googleProject.value},${bucket.getOrElse("null")}"
 }
 
-final case class K8sClusterToScan(id: Long, kubernetesClusterId: KubernetesClusterId)
-final case class NodepoolToScan(id: Long, nodepoolId: NodepoolId)
+//final case class K8sClusterToScan(id: Long, kubernetesClusterId: KubernetesClusterId)
+//final case class NodepoolToScan(id: Long, nodepoolId: NodepoolId)
 final case class KubernetesClusterToRemove(id: Long, cloudContext: CloudContext)
 
-final case class KubernetesCluster(clusterName: KubernetesClusterName, cloudContext: CloudContext, location: Location) {
+final case class KubernetesCluster(id: Long,
+                                   clusterName: KubernetesClusterName,
+                                   cloudContext: CloudContext,
+                                   location: Location
+) {
   override def toString: String = s"${cloudContext.asStringWithProvider}/${clusterName}"
 }
 

--- a/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
@@ -5,7 +5,6 @@ import doobie.Put
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
 import doobie.util.transactor.Transactor
-import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.broadinstitute.dsde.workbench.google2.{RegionName, ZoneName}
 import org.scalatest.Tag
@@ -42,12 +41,12 @@ object DbTestHelper {
   def insertDisk(disk: Disk, status: String = "Ready")(implicit xa: HikariTransactor[IO]): IO[Long] =
     insertDiskQuery(disk, status: String).withUniqueGeneratedKeys[Long]("id").transact(xa)
 
-  def insertK8sCluster(clusterId: KubernetesClusterId, status: String = "RUNNING")(implicit
+  def insertK8sCluster(cluster: KubernetesCluster, status: String = "RUNNING")(implicit
     xa: HikariTransactor[IO]
   ): IO[Long] =
     sql"""INSERT INTO KUBERNETES_CLUSTER
          (cloudContext, clusterName, location, status, creator, createdDate, destroyedDate, dateAccessed, loadBalancerIp, networkName, subNetworkName, subNetworkIpRange, region, apiServerIp, ingressChart)
-         VALUES (${clusterId.project}, ${clusterId.clusterName}, ${clusterId.location}, ${status}, "fake@broadinstitute.org", now(), now(), now(), "0.0.0.1", "network", "subnetwork", "0.0.0.1/20", ${regionName}, "35.202.56.6", "stable/nginx-ingress-1.41.3")
+         VALUES (${cluster.cloudContext.asString}, ${cluster.clusterName}, ${cluster.location}, ${status}, "fake@broadinstitute.org", now(), now(), now(), "0.0.0.1", "network", "subnetwork", "0.0.0.1/20", ${regionName}, "35.202.56.6", "stable/nginx-ingress-1.41.3")
          """.update.withUniqueGeneratedKeys[Long]("id").transact(xa)
 
   def insertNodepool(clusterId: Long, nodepoolName: String, isDefault: Boolean, status: String = "RUNNING")(implicit

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -40,7 +40,7 @@ object Generators {
                diskName,
                zone,
                formattedBy = Some("GCE")
-  ) // TODO: update generator once we support Azure disks
+  ) // TODO: update generator once we support Azure
 
   val genInitBucket: Gen[InitBucketToRemove] = for {
     project <- genGoogleProject

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -7,8 +7,7 @@ import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.scalacheck.{Arbitrary, Gen}
 
 object Generators {
-  // TODO IA-3289 When we implement Azure, make sure to add CloudService.AzureVM as an option in the line below so tests use it
-  val genCloudService: Gen[CloudService] = Gen.oneOf(CloudService.Gce, CloudService.Dataproc)
+  val genCloudService: Gen[CloudService] = Gen.oneOf(CloudService.Gce, CloudService.Dataproc, CloudService.AzureVM)
   def genRuntime(possibleStatuses: Option[NonEmptyList[String]]): Gen[Runtime] = for {
     id <- Gen.chooseNum(0, 100)
     cloudService <- genCloudService

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
@@ -50,7 +50,7 @@ object KubernetesClusterRemover {
                   } else F.unit
                 res = if (isBillingEnabled) Some(c) else None
               } yield res
-            case CloudContext.Azure(_) => logger.warn("Azure k8s clusterRemover is not supported yet").as(none)
+            case CloudContext.Azure(_) => logger.warn("Azure k8s clusterRemover is not supported").as(none)
           }
 
         } yield res

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
@@ -1,6 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
+import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper.{
   insertApp,
   insertDisk,
@@ -12,10 +13,9 @@ import com.broadinstitute.dsp.DbTestHelper.{
 }
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
-import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
-import cats.effect.unsafe.implicits.global
+
 import java.time.Instant
 
 /**
@@ -34,7 +34,7 @@ class DbReaderGetAppStuckToReportSpec extends AnyFlatSpec with CronJobsTestSuite
   val gracePeriod_creating = 7200 // in seconds
 
   it should "detect for reporting: App in DELETING or CREATING status BEYOND grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -69,7 +69,7 @@ class DbReaderGetAppStuckToReportSpec extends AnyFlatSpec with CronJobsTestSuite
   }
 
   it should "not detect for reporting: App in DELETING or CREATING status WITHIN grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper._
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
-import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -32,7 +31,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   val destroyedDateWithinGracePeriod = now.minusSeconds(gracePeriod - 150)
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -59,7 +58,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -85,7 +84,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with only a default nodepool and no apps" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId) =>
+    forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -100,7 +99,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "NOT detect for removal: Kubernetes cluster in DELETED status" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -126,7 +125,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in RUNNING status" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -153,7 +152,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -180,7 +179,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -206,7 +205,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
   }
 
   it should "detect for removal: Kubernetes cluster with nodepools but no apps" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId) =>
+    forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
@@ -1,6 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
+import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper.{
   insertApp,
   insertDisk,
@@ -13,10 +14,9 @@ import com.broadinstitute.dsp.DbTestHelper.{
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.RemovableNodepoolStatus.removableStatuses
 import doobie.scalatest.IOChecker
-import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
-import cats.effect.unsafe.implicits.global
+
 import java.time.Instant
 
 /**
@@ -40,7 +40,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   val destroyedDateWithinGracePeriod = now.minusSeconds(gracePeriod - 150)
 
   it should s"detect for removal: Nodepool in status $removableStatuses status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -67,7 +67,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should s"detect for removal: Nodepool in $removableStatuses status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -93,7 +93,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should "not detect for removal: default nodepool" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId) =>
+    forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -108,7 +108,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should "NOT detect for removal: Nodepool in DELETED status" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -134,7 +134,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in RUNNING status" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -161,7 +161,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
@@ -188,7 +188,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
   }
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
+    forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -44,7 +44,9 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
       val checker = KubernetesClusterRemover.impl(dbReader, deps)
       val res = checker.checkResource(clusterToRemove, dryRun)
 
-      res.unsafeRunSync() shouldBe Some(clusterToRemove)
+      res.unsafeRunSync() shouldBe (if (clusterToRemove.cloudContext.cloudProvider == CloudProvider.Gcp)
+                                      Some(clusterToRemove)
+                                    else None)
       if (dryRun) count shouldBe 0
       else count shouldBe 1
     }

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -43,12 +43,14 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
       val deps = initDeps(publisher)
       val checker = KubernetesClusterRemover.impl(dbReader, deps)
       val res = checker.checkResource(clusterToRemove, dryRun)
-
-      res.unsafeRunSync() shouldBe (if (clusterToRemove.cloudContext.cloudProvider == CloudProvider.Gcp)
-                                      Some(clusterToRemove)
-                                    else None)
-      if (dryRun) count shouldBe 0
-      else count shouldBe 1
+      clusterToRemove.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp =>
+          res.unsafeRunSync() shouldBe Some(clusterToRemove)
+          count shouldBe (if (dryRun) 0 else 1)
+        case CloudProvider.Azure =>
+          res.unsafeRunSync() shouldBe None
+          count shouldBe 0
+      }
     }
   }
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -43,10 +43,14 @@ final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
       val deps = initDeps(publisher)
       val checker = NodepoolRemover.impl(dbReader, deps)
       val res = checker.checkResource(n, dryRun)
-
-      res.unsafeRunSync() shouldBe (if (n.cloudContext.cloudProvider == CloudProvider.Gcp) Some(n) else None)
-      if (dryRun) count shouldBe 0
-      else count shouldBe 1
+      n.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp =>
+          res.unsafeRunSync() shouldBe Some(n)
+          count shouldBe (if (dryRun) 0 else 1)
+        case CloudProvider.Azure =>
+          res.unsafeRunSync() shouldBe None
+          count shouldBe 0
+      }
     }
   }
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -44,7 +44,7 @@ final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
       val checker = NodepoolRemover.impl(dbReader, deps)
       val res = checker.checkResource(n, dryRun)
 
-      res.unsafeRunSync() shouldBe Some(n)
+      res.unsafeRunSync() shouldBe (if (n.cloudContext.cloudProvider == CloudProvider.Gcp) Some(n) else None)
       if (dryRun) count shouldBe 0
       else count shouldBe 1
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val workbenchLibsHash = "39ff80a4-SNAP"
+  val workbenchLibsHash = "87b3b166-SNAP"
   val workbenchGoogle2Version = s"0.25-${workbenchLibsHash}"
   val workbenchAzureVersion = s"0.1-${workbenchLibsHash}"
   val openTelemetryVersion = s"0.3-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val workbenchLibsHash = "0545bbb3-SNAP"
-  val workbenchGoogle2Version = s"0.24-${workbenchLibsHash}"
+  val workbenchLibsHash = "39ff80a4-SNAP"
+  val workbenchGoogle2Version = s"0.25-${workbenchLibsHash}"
   val workbenchAzureVersion = s"0.1-${workbenchLibsHash}"
   val openTelemetryVersion = s"0.3-${workbenchLibsHash}"
   val doobieVersion = "1.0.0-RC2"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -28,7 +28,7 @@ object DbReader {
            FROM PERSISTENT_DISK AS pd1
            WHERE
            (
-             (pd1.status="Deleted" AND pd1.destroyedDate > now() - INTERVAL 30 DAY) OR 
+             (pd1.status="Deleted" AND pd1.destroyedDate > now() - INTERVAL 30 DAY) OR
              (pd1.status="Deleting" AND pd1.`dateAccessed` < now() - INTERVAL 30 MINUTE)
            ) AND
              NOT EXISTS
@@ -102,7 +102,7 @@ object DbReader {
 
   // Leonardo doesn't manage nodepool for Azure. Hence excluding Azure nodepools
   val deletedAndErroredNodepoolQuery =
-    sql"""SELECT np. id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
+    sql"""SELECT np.id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
          FROM NODEPOOL AS np
          INNER JOIN KUBERNETES_CLUSTER AS kc ON np.clusterId = kc.id
          WHERE (np.status="DELETED" OR np.status="ERROR") AND kc.cloudProvider = "GCP"

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
@@ -48,7 +48,7 @@ object DeletedOrErroredKubernetesClusterChecker {
               }
             } yield clusterOpt.fold(none[KubernetesCluster])(_ => Some(cluster))
           case CloudContext.Azure(_) =>
-            logger.warn("Resource-validator not supported for Azure kubernetes clusters").as(none)
+            logger.warn("Resource validator not supported for Azure k8s clusters").as(none)
         }
 
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterChecker.scala
@@ -47,7 +47,8 @@ object DeletedOrErroredKubernetesClusterChecker {
                 }
               }
             } yield clusterOpt.fold(none[KubernetesCluster])(_ => Some(cluster))
-          case CloudContext.Azure(_) => logger.warn("Azure is not supported yet").as(none)
+          case CloudContext.Azure(_) =>
+            logger.warn("Resource-validator not supported for Azure kubernetes clusters").as(none)
         }
 
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
@@ -56,8 +56,8 @@ object DeletedOrErroredNodepoolChecker {
               } yield nodepoolOpt.fold(none[Nodepool])(_ => Some(nodepool))
             case CloudContext.Azure(_) =>
               logger
-                .warn("Deleting Azure Nodepool is not supported yet")
-                .as(none) // TODO: IA-3623
+                .warn("Resource validator not supported for Azure nodepools")
+                .as(none)
           }
         } yield res
     }

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeChecker.scala
@@ -34,7 +34,7 @@ object StoppedRuntimeChecker {
             checkGceRuntime(x, isDryRun)
           case _: Runtime.AzureVM =>
             // TODO: IA-3289 Implement check Azure VM
-            logger.info(s"Azure VM is not supported yet").as(None)
+            logger.info(s"StoppedRuntimeChecker not supported for Azure VMs").as(None)
         }
 
       private def checkGceRuntime(runtime: Runtime.Gce, isDryRun: Boolean)(implicit

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -1,32 +1,32 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper.{insertK8sCluster, _}
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, KubernetesClusterName}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
-import cats.effect.unsafe.implicits.global
 class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config = ConfigSpec.config.database
   val transactor = yoloTransactor
 
   it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId) =>
+    forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
         val cluster2 =
-          cluster.copy(project = GoogleProject("project2"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project2")))
         val cluster3 =
-          cluster.copy(project = GoogleProject("project3"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project3")))
         val cluster4 =
-          cluster.copy(project = GoogleProject("project4"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project4")))
         val cluster5 =
-          cluster.copy(project = GoogleProject("project5"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project5")))
         val cluster6 =
-          cluster.copy(project = GoogleProject("project6"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project6")))
 
         for {
           cluster1Id <- insertK8sCluster(cluster, "DELETED")

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -11,7 +11,8 @@ import com.broadinstitute.dsp.DbTestHelper.{
 }
 import com.broadinstitute.dsp.Generators._
 import doobie.scalatest.IOChecker
-import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolName}
+import org.broadinstitute.dsde.workbench.google2.GKEModels.NodepoolName
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
@@ -19,12 +20,12 @@ class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobs
   val transactor = yoloTransactor
 
   it should "detect nodepools that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
-    forAll { (cluster: KubernetesClusterId) =>
+    forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
 
         val cluster2 =
-          cluster.copy(project = cluster.project.copy(value = s"${cluster.project}-2"))
+          cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project2")))
 
         for {
           clusterId <- insertK8sCluster(cluster)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
@@ -57,7 +57,8 @@ class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with Cron
 
       val deletedOrErroredKubernetesClusterChecker = DeletedOrErroredKubernetesClusterChecker.impl(dbReader, deps)
       val res = deletedOrErroredKubernetesClusterChecker.checkResource(cluster, dryRun)
-      res.unsafeRunSync() shouldBe Some(cluster)
+      res.unsafeRunSync() shouldBe (if (cluster.cloudContext.cloudProvider == CloudProvider.Gcp) Some(cluster)
+                                    else None)
     }
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredKubernetesClusterCheckerSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import cats.effect.unsafe.implicits.global
 
 class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "return None if kubernetes cluster no longer exists in Google" in {
+  it should "return None if kubernetes cluster no longer exists in the cloud" in {
     val gkeService = new MockGKEService {
       override def getCluster(clusterId: KubernetesClusterId)(implicit
         ev: Ask[IO, TraceId]
@@ -34,7 +34,7 @@ class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with Cron
     }
   }
 
-  it should "return KubernetesCluster if cluster still exists in Google" in {
+  it should "return KubernetesCluster if cluster still exists in the cloud" in {
     forAll { (cluster: KubernetesCluster, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getDeletedAndErroredKubernetesClusters: fs2.Stream[IO, KubernetesCluster] = Stream.emit(cluster)
@@ -57,8 +57,11 @@ class DeletedOrErroredKubernetesClusterCheckerSpec extends AnyFlatSpec with Cron
 
       val deletedOrErroredKubernetesClusterChecker = DeletedOrErroredKubernetesClusterChecker.impl(dbReader, deps)
       val res = deletedOrErroredKubernetesClusterChecker.checkResource(cluster, dryRun)
-      res.unsafeRunSync() shouldBe (if (cluster.cloudContext.cloudProvider == CloudProvider.Gcp) Some(cluster)
-                                    else None)
+      val expected = cluster.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp   => Some(cluster)
+        case CloudProvider.Azure => None
+      }
+      res.unsafeRunSync() shouldBe expected
     }
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -48,11 +48,14 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
       val deps = initNodepoolCheckerDeps(gkeService = gkeService, publisher = publisher)
       val deletedOrErroredNodepoolChecker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
-
-      res.unsafeRunSync() shouldBe (if (nodepool.cloudContext.cloudProvider == CloudProvider.Gcp) Some(nodepool)
-                                    else None)
-      if (dryRun) count shouldBe 0
-      else count shouldBe 1
+      nodepool.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp =>
+          res.unsafeRunSync() shouldBe Some(nodepool)
+          count shouldBe (if (dryRun) 0 else 1)
+        case CloudProvider.Azure =>
+          res.unsafeRunSync() shouldBe None
+          count shouldBe 0
+      }
     }
   }
 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -49,7 +49,8 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
       val deletedOrErroredNodepoolChecker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = deletedOrErroredNodepoolChecker.checkResource(nodepool, dryRun)
 
-      res.unsafeRunSync() shouldBe Some(nodepool)
+      res.unsafeRunSync() shouldBe (if (nodepool.cloudContext.cloudProvider == CloudProvider.Gcp) Some(nodepool)
+                                    else None)
       if (dryRun) count shouldBe 0
       else count shouldBe 1
     }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -17,13 +17,18 @@ import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, RegionNam
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import cats.effect.unsafe.implicits.global
+import com.azure.resourcemanager.compute.models.VirtualMachine
+import com.azure.resourcemanager.resources.fluentcore.model.Accepted
 import com.google.api.gax.longrunning.OperationFuture
 import com.google.protobuf.Empty
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
 import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "return None if runtime no longer exists in Google" in {
+  it should "return None if runtime no longer exists in the cloud" in {
     val computeService = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
         ev: Ask[IO, TraceId]
@@ -48,7 +53,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "return Runtime if runtime still exists in Google" in {
+  it should "return Runtime if runtime still exists in the cloud" in {
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getDeletedRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
@@ -80,8 +85,22 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
+      val azureVmService = new FakeAzureVmService {
+        override def getAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[VirtualMachine]] =
+          IO.pure(Some(mock[VirtualMachine]))
+        override def deleteAzureVm(name: InstanceName, cloudContext: AzureCloudContext, forceDeletion: Boolean)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[Accepted[Void]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
+      }
+
       val runtimeCheckerDeps =
-        initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
+        initRuntimeCheckerDeps(googleComputeService = computeService,
+                               googleDataprocService = dataprocService,
+                               azureVmService = azureVmService
+        )
 
       val deletedRuntimeChecker = DeletedRuntimeChecker.impl(dbReader, runtimeCheckerDeps)
       val res = deletedRuntimeChecker.checkResource(runtime, dryRun)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedRuntimeCheckerSpec.scala
@@ -90,6 +90,7 @@ class DeletedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
           ev: Ask[IO, TraceId]
         ): IO[Option[VirtualMachine]] =
           IO.pure(Some(mock[VirtualMachine]))
+
         override def deleteAzureVm(name: InstanceName, cloudContext: AzureCloudContext, forceDeletion: Boolean)(implicit
           ev: Ask[IO, TraceId]
         ): IO[Option[Accepted[Void]]] =

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -4,6 +4,8 @@ package resourceValidator
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.mtl.Ask
+import com.azure.resourcemanager.compute.models.VirtualMachine
+import com.azure.resourcemanager.resources.fluentcore.model.Accepted
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.resourceValidator.InitDependenciesHelper._
 import com.google.api.gax.longrunning.OperationFuture
@@ -12,14 +14,18 @@ import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata, ClusterStatus}
 import com.google.protobuf.Empty
 import fs2.Stream
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
 import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleComputeService}
 import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
+
 class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "return None if runtime no longer exists in Google" in {
+  it should "return None if runtime no longer exists in the cloud" in {
     val computeService = new FakeGoogleComputeService {
       override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(implicit
         ev: Ask[IO, TraceId]
@@ -44,7 +50,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "return Runtime if runtime still exists in Google" in {
+  it should "return Runtime if runtime still exists in the cloud" in {
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
         override def getErroredRuntimes: fs2.Stream[IO, Runtime] = Stream.emit(runtime)
@@ -76,8 +82,22 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
           if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
       }
 
+      val azureVmService = new FakeAzureVmService {
+        override def getAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[VirtualMachine]] =
+          IO.pure(Some(mock[VirtualMachine]))
+        override def deleteAzureVm(name: InstanceName, cloudContext: AzureCloudContext, forceDeletion: Boolean)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[Accepted[Void]]] =
+          if (dryRun) IO.raiseError(fail("this shouldn't be called")) else IO.pure(None)
+      }
+
       val runtimeCheckerDeps =
-        initRuntimeCheckerDeps(googleComputeService = computeService, googleDataprocService = dataprocService)
+        initRuntimeCheckerDeps(googleComputeService = computeService,
+                               googleDataprocService = dataprocService,
+                               azureVmService = azureVmService
+        )
 
       val erroredRuntimeChecker = ErroredRuntimeChecker.iml(dbReader, runtimeCheckerDeps)
       val res = erroredRuntimeChecker.checkResource(runtime, dryRun)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/ErroredRuntimeCheckerSpec.scala
@@ -87,6 +87,7 @@ class ErroredRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
           ev: Ask[IO, TraceId]
         ): IO[Option[VirtualMachine]] =
           IO.pure(Some(mock[VirtualMachine]))
+
         override def deleteAzureVm(name: InstanceName, cloudContext: AzureCloudContext, forceDeletion: Boolean)(implicit
           ev: Ask[IO, TraceId]
         ): IO[Option[Accepted[Void]]] =

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/InitDependenciesHelper.scala
@@ -2,8 +2,8 @@ package com.broadinstitute.dsp.resourceValidator
 
 import cats.effect.IO
 import com.broadinstitute.dsp.{CheckRunnerDeps, KubernetesClusterCheckerDeps, NodepoolCheckerDeps, RuntimeCheckerDeps}
-import org.broadinstitute.dsde.workbench.azure.AzureVmService
-import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
+import org.broadinstitute.dsde.workbench.azure.{AzureContainerService, AzureVmService}
+import org.broadinstitute.dsde.workbench.azure.mock.{FakeAzureContainerService, FakeAzureVmService}
 import org.broadinstitute.dsde.workbench.google2.mock._
 import org.broadinstitute.dsde.workbench.google2.{
   GKEService,
@@ -33,11 +33,13 @@ object InitDependenciesHelper {
     )
 
   def initKubernetesClusterCheckerDeps(gkeService: GKEService[IO] = MockGKEService,
+                                       aksService: AzureContainerService[IO] = new FakeAzureContainerService,
                                        googleStorageService: GoogleStorageService[IO] = FakeGoogleStorageInterpreter
   ) =
     KubernetesClusterCheckerDeps(
       CheckRunnerDeps(config.reportDestinationBucket, googleStorageService, FakeOpenTelemetryMetricsInterpreter),
-      gkeService
+      gkeService,
+      aksService
     )
 
   def initNodepoolCheckerDeps(gkeService: GKEService[IO] = MockGKEService,

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/StoppedRuntimeCheckerSpec.scala
@@ -113,6 +113,7 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
           ev: Ask[IO, TraceId]
         ): IO[Option[VirtualMachine]] =
           IO.pure(Some(mock[VirtualMachine]))
+
         override def stopAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
           ev: Ask[IO, TraceId]
         ): IO[Option[reactor.core.publisher.Mono[Void]]] =
@@ -127,8 +128,13 @@ final class StoppedRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite
 
       val stoppedRuntimeChecker = StoppedRuntimeChecker.iml(dbReader, runtimeCheckerDeps)
       val res = stoppedRuntimeChecker.checkResource(runtime, dryRun)
+      // TODO: IA-3289 Implement StoppedRuntimeChecker for Azure VMs
+      val expected = runtime.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp   => Some(runtime)
+        case CloudProvider.Azure => None
+      }
 
-      res.unsafeRunSync() shouldBe Some(runtime)
+      res.unsafeRunSync() shouldBe expected
     }
   }
 }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -39,7 +39,7 @@ object DbReader {
             INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
             WHERE c1.status!="Deleted" AND c1.status!="Error" AND c1.createdDate < now() - INTERVAL 1 HOUR
         """.query[Runtime]
-  
+
   val activeK8sClustersQuery =
     sql"""select id, clusterName, cloudContext, location, cloudProvider
           from

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DbReader.scala
@@ -39,13 +39,12 @@ object DbReader {
             INNER JOIN RUNTIME_CONFIG AS rt ON c1.`runtimeConfigId`=rt.id
             WHERE c1.status!="Deleted" AND c1.status!="Error" AND c1.createdDate < now() - INTERVAL 1 HOUR
         """.query[Runtime]
-
-  // Leonardo doesn't manage AKS cluster lifecycle; Hence ignoring Azure
+  
   val activeK8sClustersQuery =
     sql"""select id, clusterName, cloudContext, location, cloudProvider
           from
             KUBERNETES_CLUSTER
-          where status != "DELETED" and status != "ERROR" and cloudProvider = "GCP";
+          where status != "DELETED" and status != "ERROR";
         """.query[KubernetesCluster]
 
   val activeNodepoolsQuery =

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedKubernetesClusterChecker.scala
@@ -5,6 +5,8 @@ import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
 import fs2.Stream
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
@@ -16,29 +18,60 @@ object DeletedKubernetesClusterChecker {
   def impl[F[_]](
     dbReader: DbReader[F],
     deps: KubernetesClusterCheckerDeps[F]
-  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, K8sClusterToScan] =
-    new CheckRunner[F, K8sClusterToScan] {
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, KubernetesCluster] =
+    new CheckRunner[F, KubernetesCluster] {
       override def appName: String = zombieMonitor.appName
 
-      override def resourceToScan: Stream[F, K8sClusterToScan] = dbReader.getk8sClustersToDeleteCandidate
+      override def resourceToScan: Stream[F, KubernetesCluster] = dbReader.getk8sClustersToDeleteCandidate
 
       override def configs = CheckRunnerConfigs(s"deleted-kubernetes", false)
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 
-      def checkResource(cluster: K8sClusterToScan, isDryRun: Boolean)(implicit
+      def checkResource(cluster: KubernetesCluster, isDryRun: Boolean)(implicit
         ev: Ask[F, TraceId]
-      ): F[Option[K8sClusterToScan]] =
+      ): F[Option[KubernetesCluster]] = {
+        val isZombie = cluster.cloudContext match {
+          case CloudContext.Gcp(project) =>
+            checkGkeClusterStatus(cluster.id,
+                                  KubernetesClusterId(project, cluster.location, cluster.clusterName),
+                                  isDryRun
+            )
+          case CloudContext.Azure(cloudContext) => checkAksClusterStatus(cluster.id, cloudContext, isDryRun)
+        }
+        F.ifF(isZombie)(cluster.some, none[KubernetesCluster])
+      }
+
+      def checkGkeClusterStatus(id: Long, gkeClusterId: KubernetesClusterId, isDryRun: Boolean)(implicit
+        ev: Ask[F, TraceId]
+      ): F[Boolean] =
         for {
-          clusterOpt <- deps.gkeService.getCluster(cluster.kubernetesClusterId)
-          _ <-
-            if (isDryRun) F.unit
+          clusterOpt <- deps.gkeService.getCluster(gkeClusterId)
+          deleted <-
+            if (isDryRun) F.pure(false)
             else
               clusterOpt match {
                 case None =>
-                  logger.info(s"Going to mark k8s ${cluster} as DELETED") >> dbReader.markK8sClusterDeleted(cluster.id)
-                case Some(_) => F.unit
+                  logger.info(s"Going to mark GKE cluster ${id} as DELETED") >> dbReader.markK8sClusterDeleted(id) >> F
+                    .pure(true)
+                case Some(_) => F.pure(false)
               }
-        } yield clusterOpt.fold[Option[K8sClusterToScan]](Some(cluster))(_ => none[K8sClusterToScan])
+        } yield deleted
+
+      def checkAksClusterStatus(id: Long, cloudContext: AzureCloudContext, isDryRun: Boolean)(implicit
+        ev: Ask[F, TraceId]
+      ): F[Boolean] =
+        for {
+          clusters <- deps.aksService.listClusters(cloudContext)
+          deleted <-
+            if (isDryRun) F.pure(false)
+            else
+              clusters match {
+                case Nil =>
+                  logger.info(s"Going to mark AKS cluster ${id} as DELETED") >> dbReader.markK8sClusterDeleted(id) >> F
+                    .pure(true)
+                case _ => F.pure(false)
+              }
+        } yield deleted
     }
 }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolChecker.scala
@@ -5,6 +5,8 @@ import cats.effect.Concurrent
 import cats.mtl.Ask
 import cats.syntax.all._
 import fs2.Stream
+import org.broadinstitute.dsde.workbench.azure.AzureCloudContext
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{KubernetesClusterId, NodepoolId}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.Logger
 
@@ -19,35 +21,65 @@ object DeletedOrErroredNodepoolChecker {
   def impl[F[_]](
     dbReader: DbReader[F],
     deps: KubernetesClusterCheckerDeps[F]
-  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, NodepoolToScan] =
-    new CheckRunner[F, NodepoolToScan] {
+  )(implicit F: Concurrent[F], logger: Logger[F], ev: Ask[F, TraceId]): CheckRunner[F, Nodepool] =
+    new CheckRunner[F, Nodepool] {
       override def appName: String = zombieMonitor.appName
 
-      override def resourceToScan: Stream[F, NodepoolToScan] = dbReader.getk8sNodepoolsToDeleteCandidate
+      override def resourceToScan: Stream[F, Nodepool] = dbReader.getk8sNodepoolsToDeleteCandidate
 
       // the report file will container all zombied nodepool, and also error-ed nodepool
       override def configs = CheckRunnerConfigs(s"deleted-or-errored-nodepools", false)
 
       override def dependencies: CheckRunnerDeps[F] = deps.checkRunnerDeps
 
-      def checkResource(nodepoolToScan: NodepoolToScan, isDryRun: Boolean)(implicit
+      def checkResource(nodepool: Nodepool, isDryRun: Boolean)(implicit
         ev: Ask[F, TraceId]
-      ): F[Option[NodepoolToScan]] =
+      ): F[Option[Nodepool]] = {
+        val isZombie = nodepool.cloudContext match {
+          case CloudContext.Gcp(project) =>
+            checkGkeNodepool(
+              nodepool.nodepoolId,
+              NodepoolId(KubernetesClusterId(project, nodepool.location, nodepool.clusterName), nodepool.nodepoolName),
+              isDryRun
+            )
+          case CloudContext.Azure(cloudContext) => checkAksNodepool(nodepool.nodepoolId, cloudContext, isDryRun)
+        }
+        F.ifF(isZombie)(nodepool.some, none[Nodepool])
+      }
+
+      def checkGkeNodepool(id: Long, gkeNodepoolId: NodepoolId, isDryRun: Boolean)(implicit
+        ev: Ask[F, TraceId]
+      ): F[Boolean] =
         for {
-          nodepoolOpt <- deps.gkeService.getNodepool(nodepoolToScan.nodepoolId)
-          nodepoolToReport <- nodepoolOpt match {
-            case None =>
-              (if (isDryRun) F.unit
-               else
-                 dbReader.markNodepoolAndAppDeleted(nodepoolToScan.id)).as(Some(nodepoolToScan))
-            case Some(nodepool) =>
-              if (nodepool.getStatus == com.google.container.v1.NodePool.Status.ERROR) {
-                (if (isDryRun) F.unit
-                 else
-                   dbReader.updateNodepoolAndAppStatus(nodepoolToScan.id, "ERROR")).as(Some(nodepoolToScan))
-              } else
-                F.pure(none[NodepoolToScan])
-          }
-        } yield nodepoolToReport
+          nodepoolOpt <- deps.gkeService.getNodepool(gkeNodepoolId)
+          deleted <-
+            if (isDryRun) F.pure(false)
+            else
+              nodepoolOpt match {
+                case None =>
+                  logger.info(s"Going to mark GKE nodepool ${id} and apps as DELETED") >> dbReader
+                    .markNodepoolAndAppDeleted(id) >> F.pure(true)
+                case Some(nodepool) if nodepool.getStatus == com.google.container.v1.NodePool.Status.ERROR =>
+                  logger.info(s"Going to mark GKE nodepool ${id} and apps as ERROR") >> dbReader
+                    .updateNodepoolAndAppStatus(id, "ERROR") >> F.pure(true)
+                case _ => F.pure(false)
+              }
+        } yield deleted
+
+      def checkAksNodepool(id: Long, cloudContext: AzureCloudContext, isDryRun: Boolean)(implicit
+        ev: Ask[F, TraceId]
+      ): F[Boolean] =
+        for {
+          clusters <- deps.aksService.listClusters(cloudContext)
+          deleted <-
+            if (isDryRun) F.pure(false)
+            else
+              clusters match {
+                case Nil =>
+                  logger.info(s"Going to mark AKS nodepool ${id} and apps as DELETED") >> dbReader
+                    .markNodepoolAndAppDeleted(id) >> F.pure(true)
+                case _ => F.pure(false)
+              }
+        } yield deleted
     }
 }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ZombieMonitor.scala
@@ -80,6 +80,7 @@ object ZombieMonitor {
       runtimeCheckerDeps <- RuntimeCheckerDeps.init(appConfig.runtimeCheckerConfig, metrics, blockerBound)
       diskService <- GoogleDiskService.resource(appConfig.pathToCredential.toString, blockerBound)
       gkeService <- GKEService.resource(appConfig.pathToCredential, blockerBound)
+      _ <- Resource.eval(StructuredLogger[F].info("XXX " + appConfig.runtimeCheckerConfig.azureAppRegistration))
       aksService <- AzureContainerService.fromAzureAppRegistrationConfig(
         appConfig.runtimeCheckerConfig.azureAppRegistration
       )

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -8,8 +8,22 @@ import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleBillingInterpreter, FakeGoogleComputeService, FakeGoogleDataprocService, FakeGoogleStorageInterpreter}
-import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, GoogleBillingService, GoogleComputeService, GoogleDataprocService, GoogleStorageService, RegionName, ZoneName}
+import org.broadinstitute.dsde.workbench.google2.mock.{
+  BaseFakeGoogleDataprocService,
+  FakeGoogleBillingInterpreter,
+  FakeGoogleComputeService,
+  FakeGoogleDataprocService,
+  FakeGoogleStorageInterpreter
+}
+import org.broadinstitute.dsde.workbench.google2.{
+  DataprocClusterName,
+  GoogleBillingService,
+  GoogleComputeService,
+  GoogleDataprocService,
+  GoogleStorageService,
+  RegionName,
+  ZoneName
+}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -1,20 +1,20 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
-import cats.implicits._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
 import cats.mtl.Ask
+import com.azure.resourcemanager.compute.models.VirtualMachine
+import com.azure.resourcemanager.compute.models.PowerState
+import com.broadinstitute.dsp.Generators.{arbDataprocRuntime, genRuntime}
 import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.{
-  BaseFakeGoogleDataprocService,
-  FakeGoogleBillingInterpreter,
-  FakeGoogleComputeService,
-  FakeGoogleDataprocService,
-  FakeGoogleStorageInterpreter
-}
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
+import org.broadinstitute.dsde.workbench.azure.{AzureCloudContext, AzureVmService}
+import org.broadinstitute.dsde.workbench.google2.mock._
 import org.broadinstitute.dsde.workbench.google2.{
   DataprocClusterName,
   GoogleBillingService,
@@ -26,17 +26,15 @@ import org.broadinstitute.dsde.workbench.google2.{
 }
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
-import cats.effect.unsafe.implicits.global
-import com.broadinstitute.dsp.Generators.{arbDataprocRuntime, genRuntime}
-import org.broadinstitute.dsde.workbench.azure.AzureVmService
-import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureVmService
 import org.broadinstitute.dsde.workbench.util2.InstanceName
+import org.mockito.Mockito.when
 import org.scalacheck.Arbitrary
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
 
 class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "report a runtime if it doesn't exist in google but is still active in leonardo DB" in {
+  it should "report a runtime if it doesn't exist in the cloud but is still active in leonardo DB" in {
     implicit val arbA = Arbitrary(genRuntime(List("Running", "Creating").toNel))
 
     forAll { (runtime: Runtime, dryRun: Boolean) =>
@@ -67,7 +65,7 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "report a runtime if it's Stopped in google but is still active in leonardo DB" in {
+  it should "report a runtime if it's Stopped in the cloud but is still active in leonardo DB" in {
     import com.broadinstitute.dsp.Generators.arbRuntime
     forAll { (runtime: Runtime, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
@@ -99,14 +97,24 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         ): IO[Option[Instance]] =
           IO.pure(Some(Instance.newBuilder().setStatus(Instance.Status.TERMINATED.toString).build()))
       }
-      val deps = initRuntimeCheckerDeps(computeService, dataprocService)
+      val azureVmService = new FakeAzureVmService {
+        override def getAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[VirtualMachine]] = {
+          val vm = mock[VirtualMachine]
+          when(vm.powerState()).thenReturn(PowerState.STOPPED)
+          IO.pure(Some(vm))
+        }
+      }
+      val deps = initRuntimeCheckerDeps(computeService, dataprocService, azureVmService = azureVmService)
       val checker = ActiveRuntimeChecker.impl(dbReader, deps)
       val res = checker.checkResource(runtime, dryRun)
-      res.unsafeRunSync() shouldBe Some(runtime)
+      res.unsafeRunSync() shouldBe (if (runtime.cloudContext.cloudProvider == CloudProvider.Gcp) Some(runtime)
+                                    else None)
     }
   }
 
-  it should "not a report runtime if it still exists in google and is active in leonardo DB" in {
+  it should "not a report runtime if it still exists in the cloud and is active in leonardo DB" in {
     import com.broadinstitute.dsp.Generators.arbRuntime
 
     forAll { (runtime: Runtime, dryRun: Boolean) =>
@@ -130,7 +138,16 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
             Some(Cluster.newBuilder().setStatus(ClusterStatus.newBuilder().setState(State.RUNNING).build()).build())
           )
       }
-      val deps = initRuntimeCheckerDeps(computeService, dataprocService)
+      val azureVmService = new FakeAzureVmService {
+        override def getAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[VirtualMachine]] = {
+          val vm = mock[VirtualMachine]
+          when(vm.powerState()).thenReturn(PowerState.RUNNING)
+          IO.pure(Some(vm))
+        }
+      }
+      val deps = initRuntimeCheckerDeps(computeService, dataprocService, azureVmService = azureVmService)
       val checker = ActiveRuntimeChecker.impl(dbReader, deps)
       val res = checker.checkResource(runtime, dryRun)
       res.unsafeRunSync() shouldBe None
@@ -157,7 +174,13 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
           Some(Cluster.newBuilder().setStatus(ClusterStatus.newBuilder().setState(State.ERROR).build()).build())
         )
       }
-      val deps = initRuntimeCheckerDeps(googleDataprocService = dataprocService)
+      val azureVmService = new FakeAzureVmService {
+        override def getAzureVm(name: InstanceName, cloudContext: AzureCloudContext)(implicit
+          ev: Ask[IO, TraceId]
+        ): IO[Option[VirtualMachine]] =
+          IO.pure(Some(mock[VirtualMachine]))
+      }
+      val deps = initRuntimeCheckerDeps(googleDataprocService = dataprocService, azureVmService = azureVmService)
       val checker = ActiveRuntimeChecker.impl(dbReader, deps)
       val res = checker.checkResource(runtime, dryRun)
       res.unsafeRunSync() shouldBe Some(runtime)

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -8,22 +8,8 @@ import com.google.cloud.compute.v1.Instance
 import com.google.cloud.dataproc.v1.ClusterStatus.State
 import com.google.cloud.dataproc.v1.{Cluster, ClusterStatus}
 import fs2.Stream
-import org.broadinstitute.dsde.workbench.google2.mock.{
-  BaseFakeGoogleDataprocService,
-  FakeGoogleBillingInterpreter,
-  FakeGoogleComputeService,
-  FakeGoogleDataprocService,
-  FakeGoogleStorageInterpreter
-}
-import org.broadinstitute.dsde.workbench.google2.{
-  DataprocClusterName,
-  GoogleBillingService,
-  GoogleComputeService,
-  GoogleDataprocService,
-  GoogleStorageService,
-  RegionName,
-  ZoneName
-}
+import org.broadinstitute.dsde.workbench.google2.mock.{BaseFakeGoogleDataprocService, FakeGoogleBillingInterpreter, FakeGoogleComputeService, FakeGoogleDataprocService, FakeGoogleStorageInterpreter}
+import org.broadinstitute.dsde.workbench.google2.{DataprocClusterName, GoogleBillingService, GoogleComputeService, GoogleDataprocService, GoogleStorageService, RegionName, ZoneName}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeCheckerSpec.scala
@@ -109,8 +109,11 @@ class ActiveRuntimeCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       val deps = initRuntimeCheckerDeps(computeService, dataprocService, azureVmService = azureVmService)
       val checker = ActiveRuntimeChecker.impl(dbReader, deps)
       val res = checker.checkResource(runtime, dryRun)
-      res.unsafeRunSync() shouldBe (if (runtime.cloudContext.cloudProvider == CloudProvider.Gcp) Some(runtime)
-                                    else None)
+      val expected = runtime.cloudContext.cloudProvider match {
+        case CloudProvider.Gcp   => Some(runtime)
+        case CloudProvider.Azure => None
+      }
+      res.unsafeRunSync() shouldBe expected
     }
   }
 

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -11,12 +11,14 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.scalatest.flatspec.AnyFlatSpec
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.azure.AzureContainerService
+import org.broadinstitute.dsde.workbench.azure.mock.FakeAzureContainerService
 
 class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   it should "report nodepool if it doesn't exist in google but still active in leonardo DB" in {
-    forAll { (nodepoolToScan: NodepoolToScan, dryRun: Boolean) =>
+    forAll { (nodepoolToScan: Nodepool, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
-        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, NodepoolToScan] =
+        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, Nodepool] =
           Stream.emit(nodepoolToScan)
         override def updateNodepoolAndAppStatus(id: Long, status: String): IO[Unit] =
           if (dryRun) IO.raiseError(fail("this shouldn't be called in dryRun mode")) else IO.unit
@@ -26,7 +28,8 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
           ev: cats.mtl.Ask[IO, TraceId]
         ): IO[Option[com.google.container.v1.NodePool]] = IO.pure(None)
       }
-      val deps = initDeps(gkeService)
+      val aksService = new FakeAzureContainerService
+      val deps = initDeps(gkeService, aksService)
       val checker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = checker.checkResource(nodepoolToScan, dryRun)
       res.unsafeRunSync() shouldBe Some(nodepoolToScan)
@@ -34,9 +37,9 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
   }
 
   it should "not report nodepool if it still exists in google and active in leonardo DB" in {
-    forAll { (nodepoolToScan: NodepoolToScan, dryRun: Boolean) =>
+    forAll { (nodepoolToScan: Nodepool, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
-        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, NodepoolToScan] =
+        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, Nodepool] =
           Stream.emit(nodepoolToScan)
       }
       val gkeService = new MockGKEService {
@@ -45,7 +48,8 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
         ): IO[Option[com.google.container.v1.NodePool]] =
           IO.pure(Some(com.google.container.v1.NodePool.newBuilder().build()))
       }
-      val deps = initDeps(gkeService)
+      val aksService = new FakeAzureContainerService
+      val deps = initDeps(gkeService, aksService)
       val checker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = checker.checkResource(nodepoolToScan, dryRun)
       res.unsafeRunSync() shouldBe None
@@ -53,9 +57,9 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
   }
 
   it should "report nodepool if it still exist in google in ERROR and active in leonardo DB" in {
-    forAll { (nodepoolToScan: NodepoolToScan, dryRun: Boolean) =>
+    forAll { (nodepoolToScan: Nodepool, dryRun: Boolean) =>
       val dbReader = new FakeDbReader {
-        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, NodepoolToScan] =
+        override def getk8sNodepoolsToDeleteCandidate: Stream[IO, Nodepool] =
           Stream.emit(nodepoolToScan)
 
         override def updateNodepoolAndAppStatus(id: Long, status: String): IO[Unit] =
@@ -74,17 +78,18 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
             )
           )
       }
-      val deps = initDeps(gkeService)
+      val aksService = new FakeAzureContainerService
+      val deps = initDeps(gkeService, aksService)
       val checker = DeletedOrErroredNodepoolChecker.impl(dbReader, deps)
       val res = checker.checkResource(nodepoolToScan, dryRun)
       res.unsafeRunSync() shouldBe Some(nodepoolToScan)
     }
   }
 
-  def initDeps(gkeSerivce: GKEService[IO]): KubernetesClusterCheckerDeps[IO] = {
+  def initDeps(gkeService: GKEService[IO], aksService: AzureContainerService[IO]): KubernetesClusterCheckerDeps[IO] = {
     val config = Config.appConfig.toOption.get
     val checkRunnerDeps =
       CheckRunnerDeps(config.reportDestinationBucket, FakeGoogleStorageInterpreter, FakeOpenTelemetryMetricsInterpreter)
-    new KubernetesClusterCheckerDeps[IO](checkRunnerDeps, gkeSerivce)
+    new KubernetesClusterCheckerDeps[IO](checkRunnerDeps, gkeService, aksService)
   }
 }

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/mocks.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/mocks.scala
@@ -2,14 +2,14 @@ package com.broadinstitute.dsp.zombieMonitor
 
 import cats.effect.IO
 import com.broadinstitute.dsp
-import com.broadinstitute.dsp.{Disk, K8sClusterToScan, NodepoolToScan}
+import com.broadinstitute.dsp.{Disk, KubernetesCluster, Nodepool}
 import fs2.Stream
 
 class FakeDbReader extends DbReader[IO] {
   override def getDisksToDeleteCandidate: Stream[IO, Disk] = Stream.empty
-  override def getk8sClustersToDeleteCandidate: Stream[IO, K8sClusterToScan] = Stream.empty
+  override def getk8sClustersToDeleteCandidate: Stream[IO, KubernetesCluster] = Stream.empty
   override def getRuntimeCandidate: Stream[IO, dsp.Runtime] = Stream.empty
-  override def getk8sNodepoolsToDeleteCandidate: Stream[IO, NodepoolToScan] = Stream.empty
+  override def getk8sNodepoolsToDeleteCandidate: Stream[IO, Nodepool] = Stream.empty
   override def updateDiskStatus(id: Long): IO[Unit] = IO.unit
   override def markK8sClusterDeleted(id: Long): IO[Unit] = IO.unit
   override def updateNodepoolAndAppStatus(id: Long, status: String): IO[Unit] = IO.unit


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-3623

While working on the [Leo Apps Dashboard](https://grafana.dsp-devops.broadinstitute.org/d/mmgNHw04z/leonardo-apps?from=now-1h&to=now&var-cluster=terra-dev&var-namespace=terra-dev&var-uiClient=All&var-cloud=All&var-mrg=All&orgId=1) it became apparent that there are many Azure apps in dev in active statuses (`RUNNING`, `PROVISIONING`, etc) whose MRGs have been deleted. 

So I decided to pick up [IA-3623](https://broadworkbench.atlassian.net/browse/IA-3623) and implement the zombie-monitor cronjobs for AKS apps. The PR expanded to some additional refactoring but hopefully it's not too bad.

Brief description of changes (more context inline):
1. Slight model refactoring, remove `K8sClusterToScan` and `NodepoolToScan` classes in favor of `KubernetesCluster` and `Nodepool` which support both clouds.
2. Enabled Azure generators for unit tests, which caused some test refactoring but had to be done, I think.
3. The _actual_ change is in the cluster/nodepool checkers in `zombie-monitor`.
   - `resource-validator` and `janitor` still have Azure k8s checks disabled, I don't think it really makes sense to enable them given our AKS implementation.

I tested via unit tests; running `sbt "zombieMonitor/run --dryRun --all"` a few times; and even running a non-dryRun in dev 1 time. I think it works by inspecting the DB and checking grafana.

[IA-3623]: https://broadworkbench.atlassian.net/browse/IA-3623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ