### PR TITLE
[IA-3623 follow up] Fix SQL in resource-validator

### DIFF
--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -94,7 +94,7 @@ object DbReader {
 
   // Leonardo doesn't manage cluster for Azure. Hence excluding AKS clusters
   val deletedAndErroredKubernetesClusterQuery =
-    sql"""SELECT kc1.clusterName, cloudContext, location, cloudProvider
+    sql"""SELECT kc1.id, kc1.clusterName, cloudContext, location, cloudProvider
           FROM KUBERNETES_CLUSTER as kc1
           WHERE (kc1.status="DELETED" OR kc1.status="ERROR") AND kc1.cloudProvider = "GCP"
           """


### PR DESCRIPTION
Noticed errors in dev resource-validator: 
```
java.lang.NumberFormatException: For input string: "ke06fdd7-9d14-43a7-85d7-f7c48cf1de59"
```

https://ap-argocd.dsp-devops.broadinstitute.org/applications/leonardo-dev?resource=

In my [last PR](https://github.com/broadinstitute/leonardo-cron-jobs/pull/256/files#diff-8a5ea2275ca26bd7ff749af0903692597a4896d0857ebf98e4f66ba7fe553e2bR112) I added `id` to `KubernetesCluster` model but neglected to update all the queries.

I double-checked zombie/janitor and those seem correct -- just resource-validator was missed.