### PR TITLE
[IA-4459] update the PR generating yml file

### DIFF
--- a/.github/workflows/createPullRequest.yml
+++ b/.github/workflows/createPullRequest.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.resource-validator.outputs.changed == 'true'
         with:
           command: |
-            yq --tag '!!str' w -i charts/leonardo/values.yaml cronjob.imageTag "${{ steps.setHash.outputs.git_short_sha }}"
+            yq --tag '!!str' w -i charts/leonardo/values.yaml resourceValidatorCron.imageTag "${{ steps.setHash.outputs.git_short_sha }}"
       - name: update janitor hash
         uses: databiosphere/github-actions/actions/yq@master
         if: steps.janitor.outputs.changed == 'true'


### PR DESCRIPTION
Fixing some weirdness that happened when merging the previous PR: https://github.com/broadinstitute/terra-helmfile/pull/4515/files 

I think the Resource Validator cron job god renamed as part of the migration off fc-dev, and it's the first time we updated the cron job since then 😬 