### PR TITLE
RW-10808 update APP_USAGE table

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,22 @@ e.g. `sbt "resourceValidator/run --dryRun --all"`
   * Run each unit test individually as running them concurrently causes some of them to fail.
 
 ## Contributing
-1. Run these unit tests locally before making a PR:
-- `com.broadinstitute.dsp.zombieMonitor.DbReaderSpec`
-- `com.broadinstitute.dsp.resourceValidator.DbQueryBuilderSpec`
-- `com.broadinstitute.dsp.resourceValidator.DbReader*Spec`
-- `com.broadinstitute.dsp.janitor.DbQueryBuilderSpec`
-- `com.broadinstitute.dsp.janitor.DbReader*Spec`
 
-   These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
+1. Ideally, we should be able to just run `sbt test`. But for some reason, DB unit tests will fail if they're run this way. So you'd have to run them separately.
+
+Run DB tests by projects will have fewer failures. Here's how you can run them by each project:
+
+- `sbt zombieMonitor/test`
+
+- `sbt resourceValidator/test`
+  The following two specs will fail but should succeed when run individually
+  - `com.broadinstitute.dsp.resourceValidator.DbReaderGetDeletedOrErroredNodepoolsSpec`
+  - `com.broadinstitute.dsp.resourceValidator.DbReaderGetDeletedAndErroredKubernetesClustersSpec`
+
+- `sbt janitor/test`
+  There will be a few failures, but should succeed when run individually. (Currently `com.broadinstitute.dsp.janitor.DbQueryBuilderSpec` has real error that we need to fix at some point).
+
+  These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
 
 2. Once your PR is approved you can merge it and a new PR will be automatically created in [terra-helm](https://github.com/broadinstitute/terra-helm). 
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ Run DB tests by projects will have fewer failures. Here's how you can run them b
 - `sbt zombieMonitor/test`
 
 - `sbt resourceValidator/test`
-  There will be a few failures, but should succeed when run individually.
+  
+    There will be a few failures, but should succeed when run individually.
 
 - `sbt janitor/test`
+  
   There will be a few failures, but should succeed when run individually. (Currently `com.broadinstitute.dsp.janitor.DbQueryBuilderSpec` has real error that we need to fix at some point).
 
-  These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
+These are not run in CI, so you have to make sure you run them manually before merging any PRs. Instructions on running these can be found in the respective `DbReaderSpec` files.
 
 2. Once your PR is approved you can merge it and a new PR will be automatically created in [terra-helm](https://github.com/broadinstitute/terra-helm). 
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ Run DB tests by projects will have fewer failures. Here's how you can run them b
 - `sbt zombieMonitor/test`
 
 - `sbt resourceValidator/test`
-  The following two specs will fail but should succeed when run individually
-  - `com.broadinstitute.dsp.resourceValidator.DbReaderGetDeletedOrErroredNodepoolsSpec`
-  - `com.broadinstitute.dsp.resourceValidator.DbReaderGetDeletedAndErroredKubernetesClustersSpec`
+  There will be a few failures, but should succeed when run individually.
 
 - `sbt janitor/test`
   There will be a few failures, but should succeed when run individually. (Currently `com.broadinstitute.dsp.janitor.DbQueryBuilderSpec` has real error that we need to fix at some point).

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Run DB tests by projects will have fewer failures. Here's how you can run them b
 - `sbt zombieMonitor/test`
 
 - `sbt resourceValidator/test`
-  
-    There will be a few failures, but should succeed when run individually.
 
 - `sbt janitor/test`
   

--- a/build.sbt
+++ b/build.sbt
@@ -32,4 +32,4 @@ lazy val nuker = (project in file("nuker"))
   .enablePlugins(JavaAppPackaging)
   .dependsOn(core % "test->test;compile->compile")
 
-Test / parallelExecution := false
+concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)

--- a/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
@@ -16,12 +16,12 @@ object DbTestHelper {
   val zoneName = ZoneName("us-central1-a")
   val regionName = RegionName("us-central1")
 
-  def yoloTransactor(implicit databaseConfig: DatabaseConfig): Transactor[IO] =
+  val yoloTransactor: Transactor[IO] =
     Transactor.fromDriverManager[IO](
       "com.mysql.cj.jdbc.Driver", // driver classname
-      databaseConfig.url,
-      databaseConfig.user,
-      databaseConfig.password
+      "jdbc:mysql://localhost:3311/leotestdb?createDatabaseIfNotExist=true&useSSL=false&rewriteBatchedStatements=true&nullNamePatternMatchesAll=true&generateSimpleParameterMetadata=TRUE",
+      "leonardo-test",
+      "leonardo-test"
     )
 
   def transactorResource(implicit
@@ -158,7 +158,7 @@ object DbTestHelper {
          """.update.withUniqueGeneratedKeys[Long]("id").transact(xa)
 
   def insertAppUsage(appId: Long)(implicit
-                                  xa: HikariTransactor[IO]
+    xa: HikariTransactor[IO]
   ): IO[Int] =
     sql"""
         INSERT INTO APP_USAGE (appId, startTime, stopTime) values (${appId}, "2023-09-28 17:24:29.568559", "1970-01-01 00:00:01.000000")

--- a/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/DbTestHelper.scala
@@ -25,7 +25,7 @@ object DbTestHelper {
       logHandler = None
     )
 
-  def transactorResource(implicit
+  def isolatedDbTest(implicit
     xa: Transactor[IO]
   ): Resource[IO, Unit] =
     for {

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbQueryBuilderSpec.scala
@@ -1,7 +1,9 @@
 package com.broadinstitute.dsp
 package janitor
 
+import cats.effect.IO
 import com.broadinstitute.dsp.DbTestHelper._
+import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -14,7 +16,7 @@ import org.scalatest.flatspec.AnyFlatSpec
  */
 final class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
-  val transactor = yoloTransactor
+  implicit val transactor: Transactor[IO] = yoloTransactor
 
   it should "build kubernetesClustersToDeleteQuery properly" taggedAs DbTest in {
     check(DbReader.kubernetesClustersToDeleteQuery)

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetAppStuckToReportSpec.scala
@@ -9,7 +9,7 @@ import com.broadinstitute.dsp.DbTestHelper.{
   insertK8sCluster,
   insertNamespace,
   insertNodepool,
-  transactorResource,
+  isolatedDbTest,
   yoloTransactor
 }
 import com.broadinstitute.dsp.Generators._
@@ -37,7 +37,7 @@ class DbReaderGetAppStuckToReportSpec extends AnyFlatSpec with CronJobsTestSuite
 
   it should "detect for reporting: App in DELETING or CREATING status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -72,7 +72,7 @@ class DbReaderGetAppStuckToReportSpec extends AnyFlatSpec with CronJobsTestSuite
 
   it should "not detect for reporting: App in DELETING or CREATING status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetKubernetesClustersToDeleteSpec.scala
@@ -34,7 +34,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -61,7 +61,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -87,7 +87,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "detect for removal: Kubernetes cluster in RUNNING status with only a default nodepool and no apps" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -102,7 +102,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "NOT detect for removal: Kubernetes cluster in DELETED status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -128,7 +128,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in RUNNING status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -155,7 +155,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -182,7 +182,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "NOT detect for removal: Kubernetes cluster in RUNNING status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -208,7 +208,7 @@ final class DbReaderGetKubernetesClustersToDeleteSpec extends AnyFlatSpec with C
 
   it should "detect for removal: Kubernetes cluster with nodepools but no apps" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
@@ -9,7 +9,7 @@ import com.broadinstitute.dsp.DbTestHelper.{
   insertK8sCluster,
   insertNamespace,
   insertNodepool,
-  transactorResource,
+  isolatedDbTest,
   yoloTransactor
 }
 import com.broadinstitute.dsp.Generators._
@@ -43,7 +43,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"detect for removal: Nodepool in status $removableStatuses status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -70,7 +70,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"detect for removal: Nodepool in $removableStatuses status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -96,7 +96,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should "not detect for removal: default nodepool" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -111,7 +111,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should "NOT detect for removal: Nodepool in DELETED status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -137,7 +137,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in RUNNING status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -164,7 +164,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -191,7 +191,7 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/DbReaderGetNodepoolsToDeleteSpec.scala
@@ -1,6 +1,7 @@
 package com.broadinstitute.dsp
 package janitor
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper.{
   insertApp,
@@ -13,6 +14,7 @@ import com.broadinstitute.dsp.DbTestHelper.{
 }
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.RemovableNodepoolStatus.removableStatuses
+import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.NamespaceName
 import org.scalatest.flatspec.AnyFlatSpec
@@ -28,7 +30,7 @@ import java.time.Instant
  */
 class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
-  val transactor = yoloTransactor
+  implicit val transactor: Transactor[IO] = yoloTransactor
 
   val now = Instant.now()
   val gracePeriod = 3600 // in seconds
@@ -41,8 +43,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"detect for removal: Nodepool in status $removableStatuses status with app in DELETED status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)
@@ -68,8 +70,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"detect for removal: Nodepool in $removableStatuses status with app in ERROR status BEYOND grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatuses: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)
@@ -94,8 +96,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should "not detect for removal: default nodepool" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           clusterId <- insertK8sCluster(cluster, "RUNNING")
@@ -109,8 +111,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should "NOT detect for removal: Nodepool in DELETED status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)
@@ -135,8 +137,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in RUNNING status" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)
@@ -162,8 +164,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in DELETED status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)
@@ -189,8 +191,8 @@ class DbReaderGetNodepoolsToDeleteSpec extends AnyFlatSpec with CronJobsTestSuit
 
   it should s"NOT detect for removal: Nodepool in $removableStatuses status with app in ERROR status WITHIN grace period" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk, removableStatus: RemovableNodepoolStatus) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           diskId <- insertDisk(disk)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val workbenchGoogle2Version = s"0.32-${workbenchLibsHash}"
   val workbenchAzureVersion = s"0.5-${workbenchLibsHash}"
   val openTelemetryVersion = s"0.6-${workbenchLibsHash}"
-  val doobieVersion = "1.0.0-RC2"
+  val doobieVersion = "1.0.0-RC4"
   val declineVersion = "2.4.1"
 
   val excludeBouncyCastle = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
@@ -31,7 +31,7 @@ object Dependencies {
     "org.tpolecat" %% "doobie-scalatest" % doobieVersion % Test,
     "com.github.pureconfig" %% "pureconfig" % "0.17.4",
     "mysql" % "mysql-connector-java" % "8.0.33",
-    "org.scalatest" %% "scalatest" % "3.2.16" % Test,
+    "org.scalatest" %% "scalatest" % "3.2.17" % Test,
     "com.monovore" %% "decline" % declineVersion,
     "com.monovore" %% "decline-effect" % declineVersion,
     "dev.optics" %% "monocle-core" % "3.2.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbQueryBuilderSpec.scala
@@ -1,7 +1,9 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.effect.IO
 import com.broadinstitute.dsp.DbTestHelper._
+import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -14,7 +16,7 @@ import org.scalatest.flatspec.AnyFlatSpec
  */
 final class DbQueryBuilderSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
-  val transactor = yoloTransactor
+  implicit val transactor: Transactor[IO] = yoloTransactor
 
   it should "build deletedDisksQuery properly" taggedAs DbTest in {
     check(DbReader.shouldBedeletedDisksQuery)

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -17,7 +17,7 @@ class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec wit
 
   it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val cluster2 =

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -10,6 +10,7 @@ import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
+
 class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
   implicit val transactor: Transactor[IO] = yoloTransactor

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedAndErroredKubernetesClustersSpec.scala
@@ -1,21 +1,23 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.DbTestHelper.{insertK8sCluster, _}
 import com.broadinstitute.dsp.Generators._
+import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterName
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.scalatest.flatspec.AnyFlatSpec
 class DbReaderGetDeletedAndErroredKubernetesClustersSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
-  val transactor = yoloTransactor
+  implicit val transactor: Transactor[IO] = yoloTransactor
 
   it should "detect kubernetes clusters that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         val cluster2 =
           cluster.copy(cloudContext = CloudContext.Gcp(GoogleProject("project2")))

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletedOrErroredNodepoolsSpec.scala
@@ -7,7 +7,7 @@ import com.broadinstitute.dsp.DbTestHelper.{
   getNodepoolName,
   insertK8sCluster,
   insertNodepool,
-  transactorResource,
+  isolatedDbTest,
   yoloTransactor
 }
 import com.broadinstitute.dsp.Generators._
@@ -23,7 +23,7 @@ class DbReaderGetDeletedOrErroredNodepoolsSpec extends AnyFlatSpec with CronJobs
 
   it should "detect nodepools that are Deleted or Errored in the Leo DB" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val cluster2 =

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletingRuntimesSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletingRuntimesSpec.scala
@@ -4,7 +4,7 @@ package resourceValidator
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.Generators._
-import com.broadinstitute.dsp.DbTestHelper.{insertRuntime, insertRuntimeConfig, transactorResource, yoloTransactor}
+import com.broadinstitute.dsp.DbTestHelper.{insertRuntime, insertRuntimeConfig, isolatedDbTest, yoloTransactor}
 import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
@@ -19,7 +19,7 @@ class DbReaderGetDeletingRuntimesSpec extends AnyFlatSpec with CronJobsTestSuite
   it should "return runtimes that have been deleting for over an hour in the Leo DB" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Deleting")
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val oldTimeStamp = Instant.now.minus(2, ChronoUnit.HOURS)
@@ -36,7 +36,7 @@ class DbReaderGetDeletingRuntimesSpec extends AnyFlatSpec with CronJobsTestSuite
   it should "not return runtimes that have been deleting within the past hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Deleting")
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletingRuntimesSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DbReaderGetDeletingRuntimesSpec.scala
@@ -1,9 +1,11 @@
 package com.broadinstitute.dsp
 package resourceValidator
 
+import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.broadinstitute.dsp.Generators._
 import com.broadinstitute.dsp.DbTestHelper.{insertRuntime, insertRuntimeConfig, transactorResource, yoloTransactor}
+import doobie.Transactor
 import doobie.scalatest.IOChecker
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -12,13 +14,13 @@ import java.time.temporal.ChronoUnit
 
 class DbReaderGetDeletingRuntimesSpec extends AnyFlatSpec with CronJobsTestSuite with IOChecker {
   implicit val config: DatabaseConfig = ConfigSpec.config.database
-  val transactor = yoloTransactor
+  implicit val transactor: Transactor[IO] = yoloTransactor
 
   it should "return runtimes that have been deleting for over an hour in the Leo DB" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Deleting")
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         val oldTimeStamp = Instant.now.minus(2, ChronoUnit.HOURS)
         for {
@@ -34,8 +36,8 @@ class DbReaderGetDeletingRuntimesSpec extends AnyFlatSpec with CronJobsTestSuite
   it should "not return runtimes that have been deleting within the past hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Deleting")
-      val res = transactorResource.use { implicit xa =>
-        val dbReader = DbReader.impl(xa)
+      val res = transactorResource.use { _ =>
+        val dbReader = DbReader.impl(transactor)
 
         for {
           runtimeConfigId <- insertRuntimeConfig(runtime.cloudService)

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -53,7 +53,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
   it should "return active runtimes that are older than an hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val oldTimeStamp = new GregorianCalendar(2020, Calendar.OCTOBER, 1).getTime().toInstant
@@ -70,7 +70,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
   it should "not return runtimes that were created within the past hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
         for {
           now <- IO.realTimeInstant
@@ -85,7 +85,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "read a disk properly" taggedAs DbTest in {
     forAll { (disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val creatingDisk = disk.copy(diskName = DiskName("disk2"))
@@ -106,7 +106,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "read a KubernetesCluster properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         val precreatingCluster =
@@ -141,7 +141,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update disk properly" taggedAs DbTest in {
     forAll { (disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
         for {
           id <- insertDisk(disk)
@@ -155,7 +155,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update k8s cluster and unlink PD properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
         for {
           diskId <- insertDisk(disk)
@@ -181,7 +181,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update k8s cluster when there's no nodepool or app row" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
         for {
           clusterId <- insertK8sCluster(cluster)
@@ -195,7 +195,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update k8s cluster and nodepool when there's no App record" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
         for {
           clusterId <- insertK8sCluster(cluster)
@@ -214,7 +214,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update nodepool status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         for {
           clusterId <- insertK8sCluster(cluster)
           nodepoolId <- insertNodepool(clusterId, "nodepool1", false)
@@ -228,7 +228,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update App status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         for {
           diskId <- insertDisk(disk)
           clusterId <- insertK8sCluster(cluster)
@@ -245,7 +245,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update nodepool and app status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -268,7 +268,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update DB properly when Nodepool is deleted" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -295,7 +295,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update runtime status and unlink PD properly" taggedAs DbTest in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {
@@ -315,7 +315,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
 
   it should "update CLUSTER_ERROR table properly" taggedAs DbTest in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
-      val res = transactorResource.use { _ =>
+      val res = isolatedDbTest.use { _ =>
         val dbReader = DbReader.impl(transactor)
 
         for {

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -31,15 +31,15 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     check(DbReader.activeDisksQuery)
   }
 
-  it should "build activeK8sClustersQuery properly" taggedAs (DbTest) in {
+  it should "build activeK8sClustersQuery properly" taggedAs DbTest in {
     check(DbReader.activeK8sClustersQuery)
   }
 
-  it should "build activeNodepoolsQuery properly" taggedAs (DbTest) in {
+  it should "build activeNodepoolsQuery properly" taggedAs DbTest in {
     check(DbReader.activeNodepoolsQuery)
   }
 
-  it should "build activeRuntime properly" taggedAs (DbTest) in {
+  it should "build activeRuntime properly" taggedAs DbTest in {
     check(DbReader.activeRuntimeQuery)
   }
 
@@ -49,7 +49,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     check(DbReader.updateDiskStatusQuery(82))
   }
 
-  it should "return active runtimes that are older than an hour" taggedAs (DbTest) in {
+  it should "return active runtimes that are older than an hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
       val res = transactorResource.use { implicit xa =>
@@ -66,7 +66,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "not return runtimes that were created within the past hour" taggedAs (DbTest) in {
+  it should "not return runtimes that were created within the past hour" taggedAs DbTest in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
       val res = transactorResource.use { implicit xa =>
@@ -82,7 +82,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "read a disk properly" taggedAs (DbTest) in {
+  it should "read a disk properly" taggedAs DbTest in {
     forAll { (disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -103,7 +103,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "read a KubernetesCluster properly" taggedAs (DbTest) in {
+  it should "read a KubernetesCluster properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -138,7 +138,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update disk properly" taggedAs (DbTest) in {
+  it should "update disk properly" taggedAs DbTest in {
     forAll { (disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -152,7 +152,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster and unlink PD properly" taggedAs (DbTest) in {
+  it should "update k8s cluster and unlink PD properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -178,7 +178,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster when there's no nodepool or app row" taggedAs (DbTest) in {
+  it should "update k8s cluster when there's no nodepool or app row" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -192,7 +192,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster and nodepool when there's no App record" taggedAs (DbTest) in {
+  it should "update k8s cluster and nodepool when there's no App record" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -211,7 +211,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update nodepool status properly" taggedAs (DbTest) in {
+  it should "update nodepool status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         for {
@@ -225,7 +225,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update App status properly" taggedAs (DbTest) in {
+  it should "update App status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         for {
@@ -242,7 +242,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update nodepool and app status properly" taggedAs (DbTest) in {
+  it should "update nodepool and app status properly" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -265,7 +265,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update DB properly when Nodepool is deleted" taggedAs (DbTest) in {
+  it should "update DB properly when Nodepool is deleted" taggedAs DbTest in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -285,14 +285,14 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
         } yield {
           appStatus shouldBe "DELETED"
           nodepoolStatus shouldBe "DELETED"
-          appUsageStopTime shouldBe(appDateAccessedTime)
+          appUsageStopTime shouldBe appDateAccessedTime
         }
       }
       res.unsafeRunSync()
     }
   }
 
-  it should "update runtime status and unlink PD properly" taggedAs (DbTest) in {
+  it should "update runtime status and unlink PD properly" taggedAs DbTest in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -312,7 +312,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update CLUSTER_ERROR table properly" taggedAs (DbTest) in {
+  it should "update CLUSTER_ERROR table properly" taggedAs DbTest in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -28,7 +28,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
   implicit val databaseConfig: DatabaseConfig = ConfigSpec.config.database
   implicit val transactor: Transactor[IO] = yoloTransactor
 
-  it should "build activeDisksQuery properly" in {
+  it should "build activeDisksQuery properly" taggedAs DbTest in {
     check(DbReader.activeDisksQuery)
   }
 

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DbReaderSpec.scala
@@ -31,15 +31,15 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     check(DbReader.activeDisksQuery)
   }
 
-  it should "build activeK8sClustersQuery properly" in {
+  it should "build activeK8sClustersQuery properly" taggedAs (DbTest) in {
     check(DbReader.activeK8sClustersQuery)
   }
 
-  it should "build activeNodepoolsQuery properly" in {
+  it should "build activeNodepoolsQuery properly" taggedAs (DbTest) in {
     check(DbReader.activeNodepoolsQuery)
   }
 
-  it should "build activeRuntime properly" in {
+  it should "build activeRuntime properly" taggedAs (DbTest) in {
     check(DbReader.activeRuntimeQuery)
   }
 
@@ -49,7 +49,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     check(DbReader.updateDiskStatusQuery(82))
   }
 
-  it should "return active runtimes that are older than an hour" in {
+  it should "return active runtimes that are older than an hour" taggedAs (DbTest) in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
       val res = transactorResource.use { implicit xa =>
@@ -66,7 +66,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "not return runtimes that were created within the past hour" in {
+  it should "not return runtimes that were created within the past hour" taggedAs (DbTest) in {
     forAll { (rt: Runtime) =>
       val runtime = Runtime.setStatus(rt, "Running")
       val res = transactorResource.use { implicit xa =>
@@ -82,7 +82,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "read a disk properly" in {
+  it should "read a disk properly" taggedAs (DbTest) in {
     forAll { (disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -103,7 +103,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "read a KubernetesCluster properly" in {
+  it should "read a KubernetesCluster properly" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -138,7 +138,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update disk properly" in {
+  it should "update disk properly" taggedAs (DbTest) in {
     forAll { (disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -152,7 +152,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster and unlink PD properly" in {
+  it should "update k8s cluster and unlink PD properly" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -178,7 +178,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster when there's no nodepool or app row" in {
+  it should "update k8s cluster when there's no nodepool or app row" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -192,7 +192,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update k8s cluster and nodepool when there's no App record" in {
+  it should "update k8s cluster and nodepool when there's no App record" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -211,7 +211,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update nodepool status properly" in {
+  it should "update nodepool status properly" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster) =>
       val res = transactorResource.use { implicit xa =>
         for {
@@ -225,7 +225,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update App status properly" in {
+  it should "update App status properly" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         for {
@@ -242,7 +242,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update nodepool and app status properly" in {
+  it should "update nodepool and app status properly" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -265,7 +265,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update DB properly when Nodepool is deleted" in {
+  it should "update DB properly when Nodepool is deleted" taggedAs (DbTest) in {
     forAll { (cluster: KubernetesCluster, disk: Disk) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -292,7 +292,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update runtime status and unlink PD properly" in {
+  it should "update runtime status and unlink PD properly" taggedAs (DbTest) in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)
@@ -312,7 +312,7 @@ final class DbReaderSpec extends AnyFlatSpec with CronJobsTestSuite with IOCheck
     }
   }
 
-  it should "update CLUSTER_ERROR table properly" in {
+  it should "update CLUSTER_ERROR table properly" taggedAs (DbTest) in {
     forAll { (runtime: Runtime, cloudService: CloudService) =>
       val res = transactorResource.use { implicit xa =>
         val dbReader = DbReader.impl(xa)


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-10808

When GKE cluster or nodepool gets deleted, we should make sure APP_USAGE table is updated to record `stopTime` if there's a record for the apps on these deleted cluster or nodepool. This PR updates `stopTime` to app's `dateAccessed` time, which is the last time Leonardo knows that a user accessed the app.

I tested the query against dev DB, and I think unit test has pretty good coverage.