### PR TITLE
RW-11733 Fix a bug in janitor where in-progress nodepool is blocking kubernetes cluster deletion

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -114,7 +114,7 @@ object DbReaderImplicits {
         cloudProvider match {
           case CloudProvider.Azure =>
             throw new RuntimeException(
-              s"kubernetesCluster(${id}) is Azure cluster. This is impossible. Fix this in DB"
+              s"kubernetesCluster(${id}) is Azure cluster. We should filter out Azure clusters in the query"
             )
           case CloudProvider.Gcp =>
             KubernetesCluster(id, name, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)

--- a/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbReaderImplicits.scala
@@ -113,34 +113,30 @@ object DbReaderImplicits {
       case (id, name, cloudContextDb, location, cloudProvider) =>
         cloudProvider match {
           case CloudProvider.Azure =>
-            AzureCloudContext.fromString(cloudContextDb) match {
-              case Left(value) =>
-                throw new RuntimeException(
-                  s"${value} is not valid azure cloud context"
-                )
-              case Right(value) =>
-                KubernetesCluster(id, name, CloudContext.Azure(value), location)
-            }
+            throw new RuntimeException(
+              s"kubernetesCluster(${id}) is Azure cluster. This is impossible. Fix this in DB"
+            )
           case CloudProvider.Gcp =>
             KubernetesCluster(id, name, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
         }
     }
 
   implicit val nodepoolRead: Read[Nodepool] =
-    Read[(Long, NodepoolName, KubernetesClusterName, CloudProvider, String, Location)].map {
-      case (id, nodepoolName, k8sClusterName, cloudProvider, cloudContextDb, location) =>
+    Read[(Long, NodepoolName, Long, KubernetesClusterName, CloudProvider, String, Location)].map {
+      case (id, nodepoolName, k8sClusterId, k8sClusterName, cloudProvider, cloudContextDb, location) =>
         cloudProvider match {
           case CloudProvider.Azure =>
-            AzureCloudContext.fromString(cloudContextDb) match {
-              case Left(value) =>
-                throw new RuntimeException(
-                  s"${value} is not valid azure cloud context"
-                )
-              case Right(value) =>
-                Nodepool(id, nodepoolName, k8sClusterName, CloudContext.Azure(value), location)
-            }
+            throw new RuntimeException(
+              s"nodepool(${id}) is an Azure nodepool. This is impossible. Fix this in DB"
+            )
           case CloudProvider.Gcp =>
-            Nodepool(id, nodepoolName, k8sClusterName, CloudContext.Gcp(GoogleProject(cloudContextDb)), location)
+            Nodepool(id,
+                     nodepoolName,
+                     k8sClusterId,
+                     k8sClusterName,
+                     CloudContext.Gcp(GoogleProject(cloudContextDb)),
+                     location
+            )
         }
     }
 }

--- a/core/src/main/scala/com/broadinstitute/dsp/models.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/models.scala
@@ -59,6 +59,7 @@ final case class KubernetesCluster(id: Long,
 
 final case class Nodepool(nodepoolId: Long,
                           nodepoolName: NodepoolName,
+                          kubernetesClusterId: Long,
                           clusterName: KubernetesClusterName,
                           cloudContext: CloudContext,
                           location: Location

--- a/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
+++ b/core/src/test/scala/com/broadinstitute/dsp/Generators.scala
@@ -61,32 +61,17 @@ object Generators {
 
   val genNodepool: Gen[Nodepool] = for {
     id <- Gen.chooseNum(0, 100)
+    k8sClusterId <- Gen.chooseNum(0, 100)
     nodepoolName <- genNodepoolName
     clusterName <- Gen.uuid.map(x => KubernetesClusterName(x.toString))
-    cloudService <- genCloudService
     project <- genGoogleProject
-    azureCloudContext <- genAzureCloudContext
     location <- genLocation
-  } yield cloudService match {
-    case CloudService.Gce => Nodepool(id, nodepoolName, clusterName, CloudContext.Gcp(project), location)
-
-    case CloudService.Dataproc => Nodepool(id, nodepoolName, clusterName, CloudContext.Gcp(project), location)
-
-    case CloudService.AzureVM =>
-      Nodepool(id, nodepoolName, clusterName, CloudContext.Azure(azureCloudContext), location)
-
-  }
+  } yield Nodepool(id, nodepoolName, k8sClusterId, clusterName, CloudContext.Gcp(project), location)
 
   val genKubernetesClusterToRemove: Gen[KubernetesClusterToRemove] = for {
     id <- Gen.chooseNum(0, 100)
-    cloudService <- genCloudService
     project <- genGoogleProject
-    azureCloudContext <- genAzureCloudContext
-  } yield cloudService match {
-    case CloudService.Gce      => KubernetesClusterToRemove(id, CloudContext.Gcp(project))
-    case CloudService.Dataproc => KubernetesClusterToRemove(id, CloudContext.Gcp(project))
-    case CloudService.AzureVM  => KubernetesClusterToRemove(id, CloudContext.Azure(azureCloudContext))
-  }
+  } yield KubernetesClusterToRemove(id, CloudContext.Gcp(project))
 
   val genRuntimeWithWorkers: Gen[RuntimeWithWorkers] = for {
     runtime <- genDataprocRuntime

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -60,6 +60,7 @@ object DbReader {
       FROM KUBERNETES_CLUSTER kc
       WHERE
         kc.status != "DELETED" AND
+        kc.cloudProvider = "GCP" AND
         NOT EXISTS (
           SELECT *
           FROM NODEPOOL np
@@ -95,6 +96,7 @@ object DbReader {
         WHERE
         (
             np.status IN ("STATUS_UNSPECIFIED", "RUNNING", "RECONCILING", "ERROR", "RUNNING_WITH_ERROR")
+            AND kc.cloudProvider = "GCP"
             AND np.isDefault = 0
             AND NOT EXISTS
             (

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -45,8 +45,9 @@ object DbReader {
   implicit def apply[F[_]](implicit ev: DbReader[F]): DbReader[F] = ev
 
   /**
-   * Return all non-deleted clusters with non-default nodepools that have apps that were all deleted
-   * or errored outside the grace period (1 hour)
+   * Return all non-deleted GCP clusters with non-default nodepools that have apps that were all deleted
+   * or errored outside the grace period (1 hour). Note Azure Kubernetes clusters's lifecycle are managed by WSM separately. Hence
+   * we don't need to check for Azure clusters.
    * We are including clusters with no nodepools and apps as well.
    * We are calculating the grace period for cluster deletion assuming that the following are valid proxies
    * for an app's last activity:

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -88,7 +88,7 @@ object DbReader {
   // TODO: Read the grace period (hardcoded to '1 HOUR' below) from config
   val applessNodepoolQuery =
     sql"""
-        SELECT np.id, np.nodepoolName, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
+        SELECT np.id, np.nodepoolName, kc.id, kc.clusterName, kc.cloudProvider, kc.cloudContext, kc.location
         FROM NODEPOOL AS np
         INNER JOIN KUBERNETES_CLUSTER AS kc
         ON np.clusterId = kc.id

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
@@ -22,13 +22,13 @@ object NodepoolRemover {
         val res = for {
           kubernetesClusterToRemoveCandidates <- dbReader.getKubernetesClustersToDelete.compile.toList
           kubernestesClusterToRemoveIds = kubernetesClusterToRemoveCandidates.map(_.id)
-          nodepoolTORemoveCandidate <- dbReader.getNodepoolsToDelete
+          nodepoolToRemoveCandidates <- dbReader.getNodepoolsToDelete
             .filter { n =>
               !kubernestesClusterToRemoveIds.contains(n.kubernetesClusterId)
             }
             .compile
             .toList
-        } yield nodepoolTORemoveCandidate
+        } yield nodepoolToRemoveCandidates
         Stream.evals(res)
       }
 

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
@@ -21,8 +21,11 @@ object NodepoolRemover {
       override def resourceToScan: Stream[F, Nodepool] = {
         val res = for {
           kubernetesClusterToRemoveCandidates <- dbReader.getKubernetesClustersToDelete.compile.toList
+          kubernestesClusterToRemoveIds = kubernetesClusterToRemoveCandidates.map(_.id)
           nodepoolTORemoveCandidate <- dbReader.getNodepoolsToDelete
-            .filter(n => !kubernetesClusterToRemoveCandidates.contains(n.kubernetesClusterId))
+            .filter { n =>
+              !kubernestesClusterToRemoveIds.contains(n.kubernetesClusterId)
+            }
             .compile
             .toList
         } yield nodepoolTORemoveCandidate

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,8 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-azure" % workbenchAzureVersion % Test classifier "tests",
     "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
     "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
-    "ca.mrvisser" %% "sealerate" % "0.0.6"
+    "ca.mrvisser" %% "sealerate" % "0.0.6",
+    "com.google.cloud" % "google-cloud-nio" % "0.127.7" % Test classifier "tests"
   )
 
   val resourceValidator =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,9 @@ object Dependencies {
   val excludeResourceManagerMsi =
     ExclusionRule(organization = "com.azure.resourcemanager", name = s"azure-resourcemanager-msi")
 
+  val googleCloudNio: ModuleID =
+    "com.google.cloud" % "google-cloud-nio" % "0.127.9" % Test // brought in for FakeStorageInterpreter
+
   val core = Seq(
     "net.logstash.logback" % "logstash-logback-encoder" % "7.4",
     "ch.qos.logback" % "logback-classic" % "1.4.11",
@@ -52,7 +55,7 @@ object Dependencies {
     "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
     "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
     "ca.mrvisser" %% "sealerate" % "0.0.6",
-    "com.google.cloud" % "google-cloud-nio" % "0.127.9" % Test classifier "tests"
+    googleCloudNio
   )
 
   val resourceValidator =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
     "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
     "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0" % Test, // https://github.com/scalatest/scalatestplus-selenium
     "ca.mrvisser" %% "sealerate" % "0.0.6",
-    "com.google.cloud" % "google-cloud-nio" % "0.127.7" % Test classifier "tests"
+    "com.google.cloud" % "google-cloud-nio" % "0.127.9" % Test classifier "tests"
   )
 
   val resourceValidator =


### PR DESCRIPTION
https://precisionmedicineinitiative.atlassian.net/browse/RW-11733

Currently, the nodepool remover and kubernetes cluster remover run independently. This has an issue where if the nodepool candidate is on a kubernetes cluster candidate, then the kubernetes cluster deletion will fail with the following error from GCP.

```
com.google.api.gax.rpc.FailedPreconditionException: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: Operation operation-1705676420312-89e6513c-2489-4804-b954-e8a633291ba4 is currently deleting a node pool for cluster k0a6c961-d599-4f5c-9dea-c01e15c9293a. Please wait and try again once it is done.
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:102)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:98)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:66)
	at com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:97)
	at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:84)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1127)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:807)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:568)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:538)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at com.google.api.gax.grpc.ChannelPool$ReleasingClientCall$1.onClose(ChannelPool.java:570)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:574)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:72)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:742)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:723)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
	at map @ org.broadinstitute.dsde.workbench.google2.package$.recoverF(package.scala:97)
	at recover$extension @ org.broadinstitute.dsde.workbench.google2.GoogleSubscriberInterpreter$.createSubscription(GoogleSubscriberInterpreter.scala:265)
	at modify @ fs2.internal.Scope.close(Scope.scala:262)
	Suppressed: com.google.api.gax.rpc.AsyncTaskException: Asynchronous task failed
		at com.google.api.gax.rpc.ApiExceptions.callAndTranslateApiException(ApiExceptions.java:57)
		at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
		at com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(ClusterManagerClient.java:1908)
		at com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(ClusterManagerClient.java:1825)
		at org.broadinstitute.dsde.workbench.google2.GKEInterpreter.$anonfun$deleteCluster$1(GKEInterpreter.scala:64)
		at cats.effect.unsafe.WorkerThread.blockOn(WorkerThread.scala:676)
		at scala.concurrent.package$.blocking(package.scala:124)
		at cats.effect.IOFiber.runLoop(IOFiber.scala:951)
		at cats.effect.IOFiber.execR(IOFiber.scala:1317)
		at cats.effect.IOFiber.run(IOFiber.scala:112)
		at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:585)
Caused by: io.grpc.StatusRuntimeException: FAILED_PRECONDITION: Operation operation-1705676420312-89e6513c-2489-4804-b954-e8a633291ba4 is currently deleting a node pool for cluster k0a6c961-d599-4f5c-9dea-c01e15c9293a. Please wait and try again once it is done.
	at io.grpc.Status.asRuntimeException(Status.java:537)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:538)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at com.google.api.gax.grpc.ChannelPool$ReleasingClientCall$1.onClose(ChannelPool.java:570)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:574)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:72)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:742)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:723)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

When this happens, the k8s cluster is left in a bad state, hence blocking users from creating apps in the project.

This PR excludes nodepool candidates if they're on one of the k8s cluster candidates to remove.


Tested by running locally against dev DB.
See the log messages (not actual prod logs) below that we have list of k8s clusters to remove, and there's no nodepool candidates to remove because they are on one of the clusters candidates to remove already.
```
{"@timestamp":"2024-01-26T19:14:35.134348Z","@version":"1","logger_name":"com.broadinstitute.dsp.janitor.Janitor","thread_name":"io-compute-blocker-2","severity":"INFO","serviceContext":{"service":"leonardo-cron-jobs","version":"389a91a"},"message":"clusters to remove: List(293, 295, 296, 308, 310, 1480, 1827, 1845, 1876, 1897, 1913)"}
{"@timestamp":"2024-01-26T19:14:35.431764Z","@version":"1","logger_name":"com.broadinstitute.dsp.janitor.Janitor","thread_name":"io-compute-blocker-5","severity":"INFO","serviceContext":{"service":"leonardo-cron-jobs","version":"389a91a"},"message":"nodepools to remove List()"}
```