### PR TITLE
[IA-4578] delete zombie runtime if billing disabled

### DIFF
--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
@@ -106,12 +106,12 @@ object ActiveRuntimeChecker {
       def checkGceRuntimeStatus(runtime: Runtime.Gce, isDryRun: Boolean): F[Option[Runtime]] =
         for {
           isBillingEnabled <- deps.billingService.isBillingEnabled(runtime.googleProject)
-          runtimeOpt <- if (isBillingEnabled)
-            deps
-              .computeService
-              .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
-          else
-            F.pure(none[Instance])
+          runtimeOpt <-
+            if (isBillingEnabled)
+              deps.computeService
+                .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
+            else
+              F.pure(none[Instance])
           res <-
             runtimeOpt match {
               case None =>

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/ActiveRuntimeChecker.scala
@@ -105,8 +105,13 @@ object ActiveRuntimeChecker {
 
       def checkGceRuntimeStatus(runtime: Runtime.Gce, isDryRun: Boolean): F[Option[Runtime]] =
         for {
-          runtimeOpt <- deps.computeService
-            .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
+          isBillingEnabled <- deps.billingService.isBillingEnabled(runtime.googleProject)
+          runtimeOpt <- if (isBillingEnabled)
+            deps
+              .computeService
+              .getInstance(runtime.googleProject, runtime.zone, InstanceName(runtime.runtimeName))
+          else
+            F.pure(none[Instance])
           res <-
             runtimeOpt match {
               case None =>


### PR DESCRIPTION
## IA-4578: handle disabled billing project
https://broadworkbench.atlassian.net/browse/IA-4578

Zombie Monitor checks active runtimes every 4 hours:
- All runtimes in CLUSTER table with status not Deleted or Error, more than an hour old
- Requests the runtime instance using Google Compute API (see GoogleComputeInterpreter)
- If response errors on 404, or errors with text "requires billing to be enabled", delete the runtime record in Leonardo (see ActiveRuntimeChecker)

In a disabled Google billing project, I manually set a runtime record's status to Deleting, then triggered Zombie Monitor (https://console.cloud.google.com/kubernetes/cronjob/us-central1-a/terra-dev/terra-dev/leonardo-zombie-monitor-cronjob/logs?project=broad-dsde-dev)
- I saw a 403 Forbidden error for the runtime, with the message "Compute Engine API has not been used in project terra-vpc-sc-dev-8634498f before or it is disabled."
- The runtime record was not updated to Deleted
- The disabled project no longer has access to the Compute Engine API.

When the Google billing for a project is disabled, Google revokes access to the Compute Engine API, which is a paid API. The call is forbidden before it can return information about the billing status.

This workaround is to check for the billing account enablement status before making the Compute Engine request.

## testing IA-4578
- Using a BEE
- configure your local `leonardo-cron-jobs` to connect to your BEE (https://github.com/broadinstitute/leonardo-cron-jobs?tab=readme-ov-file#running-locally)
  - LEONARDO_DB_USER and LEONARDO_DB_PASSWORD from your own CloudSQL instance
  - LEONARDO_PATH_TO_CREDENTIAL = `/etc/leonardo-account.json`
  - reference.conf needs 
    - a `leonardo-pubsub.google-project` = `terra-qa-bees`
    - a `report-destination-bucket` - what is this for a BEE?
- Create a new GCP billing in Google Cloud Platform (ask Rob Title?)
- In Terra, make a new Terra billing project using GCP billing
- Terra: new GCP workspace in the project
- Terra: new GCP runtime in the workspace (note project and runtime's Google uuid)
- Wait 1 hour
- make a DB connection (cloud_sql_proxy to the leonardo CloudSQL instance used by your BEE)
- Cronjobs: run zombie-monitor locally (presumably its output will go to the report-destination-bucket!)
  - Check output for mention of your project+runtime
  - No change should have been made
- GCP: disable your billing account (e.g. here (but don't disable this, this is QA) https://console.cloud.google.com/billing/010028-6EECA7-A9876F/manage?project=broad-dsde-qa&supportedpurview=project)
- Terra: verify your runtime still appears in your Cloud Environments
- Cronjobs: run zombie-monitor locally
  - Check output: your project+runtime should have generated an error message (either 403 Forbidden with mention of the Compute Engine API or 401 with mention of the billing account)
- Terra: verify your runtime is gone from Cloud Environments
- SQL: verify the leonardo DB record for your runtime has status Deleted