### PR TITLE
IA-4823  add destroyedDate condition

### DIFF
--- a/core/src/main/scala/com/broadinstitute/dsp/DbTransactor.scala
+++ b/core/src/main/scala/com/broadinstitute/dsp/DbTransactor.scala
@@ -5,6 +5,7 @@ import doobie.ExecutionContexts
 import doobie.hikari.HikariTransactor
 
 object DbTransactor {
+  val leonardoDummyDate = "1970-01-01 00:00:01.000000"
   def init[F[_]: Async](databaseConfig: DatabaseConfig): Resource[F, HikariTransactor[F]] =
     for {
       fixedThreadPool <- ExecutionContexts.fixedThreadPool(100)

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -32,7 +32,7 @@ object DbReader {
            (
              (pd1.status="Deleted" AND pd1.destroyedDate > now() - INTERVAL 30 DAY) OR
              (pd1.status="Deleting" AND pd1.`dateAccessed` < now() - INTERVAL 30 MINUTE) OR
-             (pd1.destroyedDate == ${leonardoDummyDate})
+             (pd1.status="Deleted" AND pd1.destroyedDate == ${leonardoDummyDate})
            ) AND
              NOT EXISTS
              (

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -3,6 +3,7 @@ package resourceValidator
 
 import cats.effect.Async
 import com.broadinstitute.dsp.DbReaderImplicits._
+import com.broadinstitute.dsp.DbTransactor.leonardoDummyDate
 import doobie._
 import doobie.implicits._
 import fs2.Stream
@@ -30,7 +31,8 @@ object DbReader {
            WHERE
            (
              (pd1.status="Deleted" AND pd1.destroyedDate > now() - INTERVAL 30 DAY) OR
-             (pd1.status="Deleting" AND pd1.`dateAccessed` < now() - INTERVAL 30 MINUTE)
+             (pd1.status="Deleting" AND pd1.`dateAccessed` < now() - INTERVAL 30 MINUTE) OR
+             (pd1.destroyedDate == ${leonardoDummyDate})
            ) AND
              NOT EXISTS
              (


### PR DESCRIPTION
We recently noticed that some PDs may have been marked as "Deleted" but without `destroyedDate` due to a bug. For these disks, cron job currently isn't validating whether they're indeed deleted in GCP, which can cause unexpected expense.

This PR adds these PDs to be scanned by the resource validator