### PR TITLE
Revert "IA-4823 look for runtimes without destroyedDate as well"

### DIFF
--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -50,11 +50,8 @@ object DbReader {
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
-            (
-              (c1.status = "Deleted" AND c1.destroyedDate > now() - INTERVAL 30 DAY) OR
-              (c1.status="Deleted" AND c1.destroyedDate = '1970-01-01 00:00:01.000000')
-            )
-            AND
+            c1.status = "Deleted" AND
+            c1.destroyedDate > now() - INTERVAL 30 DAY AND
             NOT EXISTS (
               SELECT *
               FROM CLUSTER AS c2


### PR DESCRIPTION
Reverts broadinstitute/leonardo-cron-jobs#328



So I ran the job in prod, and it's finding ones that shouldn't be deleted for some reason. so revert for now until we can understand why that's happening

see `runtime_anomalies` tab in https://docs.google.com/spreadsheets/d/1L4xMydpufZsYWYaZ4AleZwemJVLSdrePxFXVoBvfNFg/edit#gid=145896178