### PR TITLE
IA-4871  Include destroyedDate in the deletedRuntime checker and fix a bug where we're including runtimes that shouldn't have been deleted

### DIFF
--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -50,15 +50,18 @@ object DbReader {
           FROM CLUSTER AS c1
           INNER JOIN RUNTIME_CONFIG AS rt ON c1.runtimeConfigId = rt.id
           WHERE
-            c1.status = "Deleted" AND
-            c1.destroyedDate > now() - INTERVAL 30 DAY AND
+            (
+              (c1.status = "Deleted" AND c1.destroyedDate > now() - INTERVAL 30 DAY) OR
+              (c1.status="Deleted" AND c1.destroyedDate = '1970-01-01 00:00:01.000000')
+            )
+            AND
             NOT EXISTS (
               SELECT *
               FROM CLUSTER AS c2
               WHERE
                 c2.cloudContext = c1.cloudContext AND
                 c2.runtimeName = c1.runtimeName AND
-                (c2.status = "Stopped" OR c2.status = "Running")
+                (c2.status != "Deleted" OR c2.status != "Deleting")
           )"""
       .query[Runtime]
 
@@ -75,7 +78,7 @@ object DbReader {
               WHERE
                 c2.cloudContext = c1.cloudContext AND
                 c2.runtimeName = c1.runtimeName AND
-                (c2.status = "Stopped" OR c2.status = "Running")
+                (c2.status != "Deleted" OR c2.status != "Deleting")
           )"""
       .query[Runtime]
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DbReader.scala
@@ -61,7 +61,8 @@ object DbReader {
               WHERE
                 c2.cloudContext = c1.cloudContext AND
                 c2.runtimeName = c1.runtimeName AND
-                (c2.status != "Deleted" OR c2.status != "Deleting")
+                c2.status != "Deleted" AND
+                c2.status != "Deleting"
           )"""
       .query[Runtime]
 
@@ -78,7 +79,8 @@ object DbReader {
               WHERE
                 c2.cloudContext = c1.cloudContext AND
                 c2.runtimeName = c1.runtimeName AND
-                (c2.status != "Deleted" OR c2.status != "Deleting")
+                c2.status != "Deleted" AND
+                c2.status != "Deleting"
           )"""
       .query[Runtime]
 


### PR DESCRIPTION
1. Add back the `destroyedDate` condition from previous reverted PR
2. Fix a bug where we're detecting some runtimes as anomalies incorrectly.

Here's the bug. Take the following as an example
```
123099, all-of-us-6490, terra-vpc-sc-60fd067e, Deleted, 2023-11-12 00:48:55.071059, 2023-11-12 01:21:27.304278...
149253, all-of-us-6490, terra-vpc-sc-60fd067e, Stopping, 2024-03-18 00:48:55.071059, 1970-01-01 00:00:01.000000...
```

123099 should've been excluded becuz 149253 is in the same project with the same name that is still active (this is because AoU re-uses runtime names when creating new runtimes in the same project for the same user). But the query condition is not excluding 123099 because 149253's status is `Stopping` and the `NOT EXISTS` is only looking for `Stopped` and `Running`
```
 NOT EXISTS (
              SELECT *
              FROM CLUSTER AS c2
              WHERE
                c2.cloudContext = c1.cloudContext AND
                c2.runtimeName = c1.runtimeName AND
                (c2.status = "Stopped" OR c2.status = "Running"))
```
