### PR TITLE
RW-12296 Added unit tests for zombieMonitor DeletedDiskChecker

### DIFF
--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -70,7 +70,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader).updateDiskStatus(anyLong())
+      verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
   it should "not call updateDiskStatus with error 'billing is disabled'  (isDryRun = true)" in {
@@ -87,14 +87,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       )
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = true)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
 
@@ -112,14 +112,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       )
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = false)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader).updateDiskStatus(anyLong())
+      verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
   it should "not call updateDiskStatus with error 'compute engine has not been setup' (isDryRun = true)" in {
@@ -136,14 +136,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       )
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = true)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
 
@@ -164,14 +164,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       )
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = false)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
 
@@ -185,14 +185,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       ).thenAnswer(_ => IO.pure(None))
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = false)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader).updateDiskStatus(anyLong())
+      verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
   it should "not call updateDiskStatus when getDisk returns no disk (isDryRun = true)" in {
@@ -205,14 +205,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       ).thenAnswer(_ => IO.pure(None))
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = true)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
 
@@ -227,14 +227,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       ).thenAnswer(_ => IO.pure(Some(googleDisk)))
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = false)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
   it should "not call updateDiskStatus when getDisk returns a disk (isDryRun = true)" in {
@@ -248,14 +248,14 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
         )
       ).thenAnswer(_ => IO.pure(Some(googleDisk)))
 
-      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+      when(mockDbReader.updateDiskStatus(disk.id)).thenReturn(IO.unit)
 
       // Act
       val res = checker.checkResource(disk, isDryRun = true)
       res.unsafeRunSync()
 
       // Assert
-      verify(mockDbReader, never()).updateDiskStatus(anyLong())
+      verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
 }

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -1,0 +1,11 @@
+package com.broadinstitute.dsp
+package zombieMonitor
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
+  it should "return None if disk no longer exists in Google" in {
+    true shouldBe false
+  }
+
+}

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -48,7 +48,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
   }
 
-  it should "call updateDiskStatus when billing is disabled" in {
+  it should "call updateDiskStatus when billing is disabled (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -73,7 +73,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "call updateDiskStatus when compute engine has not been setup" in {
+  it should "call updateDiskStatus when compute engine has not been setup (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -98,7 +98,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus when unexpected exception is thrown" in {
+  it should "not call updateDiskStatus when unexpected exception is thrown (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -126,7 +126,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus when billing is disabled and run in dryRun mode" in {
+  it should "not call updateDiskStatus when billing is disabled and run (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -151,7 +151,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus when compute engine has not been setup and run in dryRun mode" in {
+  it should "not call updateDiskStatus when compute engine has not been setup (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -176,7 +176,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus when getDisk returns no disk in dryRun mode" in {
+  it should "not call updateDiskStatus when getDisk returns no disk (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -196,7 +196,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader, never()).updateDiskStatus(anyLong())
     }
   }
-  it should "not call updateDiskStatus when getDisk returns a disk in dryRun mode" in {
+  it should "not call updateDiskStatus when getDisk returns a disk (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -219,7 +219,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
   }
 
 
-  it should "call updateDiskStatus when getDisk returns no disk" in {
+  it should "call updateDiskStatus when getDisk returns no disk (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -239,7 +239,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader).updateDiskStatus(anyLong())
     }
   }
-  it should "not call updateDiskStatus when getDisk returns a disk" in {
+  it should "not call updateDiskStatus when getDisk returns a disk (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -15,17 +15,26 @@ import org.mockito.ArgumentMatchers.{any, anyLong, anyString}
 import org.mockito.Mockito.{mock, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 
-class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
+class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite{
+
+  var mockDbReader: DbReader[IO] = _
+  var mockCheckRunnerDeps: CheckRunnerDeps[IO] = _
+  var mockGoogleDiskService: GoogleDiskService[IO] = _
+  var mockDiskCheckerDeps: DiskCheckerDeps[IO] = _
+  var checker: CheckRunner[IO, Disk] = _
+  def setupMocks(): Unit = {
+    mockDbReader = mock(classOf[DbReader[IO]])
+    mockCheckRunnerDeps = mock(classOf[CheckRunnerDeps[IO]])
+    mockGoogleDiskService = mock(classOf[GoogleDiskService[IO]])
+    mockDiskCheckerDeps = DiskCheckerDeps(mockCheckRunnerDeps, mockGoogleDiskService)
+    checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
+  }
+
   it should "call updateDiskStatus when billing is disabled" in {
 
     forAll { (disk: Disk) =>
       // Arrange
-      val mockDbReader = mock(classOf[DbReader[IO]])
-      val mockCheckRunnerDeps = mock(classOf[CheckRunnerDeps[IO]])
-      val mockGoogleDiskService = mock(classOf[GoogleDiskService[IO]])
-      val mockDiskCheckerDeps = DiskCheckerDeps(mockCheckRunnerDeps, mockGoogleDiskService)
-      val checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
-
+      setupMocks()
       when(
         mockGoogleDiskService.getDisk(any[GoogleProject], ZoneName(anyString()), DiskName(anyString()))(
           any[Ask[IO, TraceId]]

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -15,7 +15,7 @@ import org.mockito.ArgumentMatchers.{any, anyLong, anyString}
 import org.mockito.Mockito.{mock, never, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 
-class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite{
+class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
 
   var mockDbReader: DbReader[IO] = _
   var mockCheckRunnerDeps: CheckRunnerDeps[IO] = _
@@ -69,8 +69,8 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite{
       ).thenAnswer(_ =>
         IO.raiseError(
           new PermissionDeniedException(new Exception("Compute Engine API has not been used"),
-            GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
-            false
+                                        GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
+                                        false
           )
         )
       )
@@ -97,8 +97,8 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite{
       ).thenAnswer(_ =>
         IO.raiseError(
           new InternalException(new Exception("Compute Engine API has not been used"),
-            GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
-            false
+                                GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
+                                false
           )
         )
       )

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -55,9 +55,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
   }
 
-  for (
-    (title, getDiskResponse) <- gcpFailureConditions
-  )
+  for ((title, getDiskResponse) <- gcpFailureConditions)
     it should s"updateDiskStatus when $title (isDryRun = false)" in {
       forAll { (disk: Disk) =>
         // Arrange
@@ -79,9 +77,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       }
     }
 
-  for (
-    (title, getDiskResponse) <- gcpFailureConditions
-  )
+  for ((title, getDiskResponse) <- gcpFailureConditions)
     it should s"not updateDiskStatus when $title (isDryRun = true)" in {
       forAll { (disk: Disk) =>
         // Arrange
@@ -114,8 +110,8 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       ).thenAnswer(_ =>
         IO.raiseError(
           new InternalException(new Exception("Something unexpected happened"),
-            GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
-            false
+                                GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),
+                                false
           )
         )
       )

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -1,11 +1,47 @@
 package com.broadinstitute.dsp
 package zombieMonitor
 
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.mtl.Ask
+import com.broadinstitute.dsp.Generators._
+import com.google.api.gax.grpc.GrpcStatusCode
+import com.google.api.gax.rpc.PermissionDeniedException
+import io.grpc.Status
+import org.broadinstitute.dsde.workbench.google2.{DiskName, GoogleDiskService, ZoneName}
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.mockito.ArgumentMatchers.{any, anyLong, anyString}
+import org.mockito.Mockito.{mock, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
-  it should "return None if disk no longer exists in Google" in {
-    true shouldBe false
-  }
+  it should "call updateDiskStatus when billing is disabled" in {
 
+    forAll { (disk: Disk) =>
+      //Arrange
+      val mockDbReader = mock(classOf[DbReader[IO]])
+      val mockCheckRunnerDeps = mock(classOf[CheckRunnerDeps[IO]])
+      val mockGoogleDiskService = mock(classOf[GoogleDiskService[IO]])
+      val mockDiskCheckerDeps = DiskCheckerDeps(mockCheckRunnerDeps, mockGoogleDiskService)
+      val checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
+
+      when(mockGoogleDiskService.getDisk(any[GoogleProject], ZoneName(anyString()), DiskName(anyString()))(
+        any[Ask[IO, TraceId]]
+      )).thenAnswer(_ =>
+        IO.raiseError(new PermissionDeniedException(new Exception("This API method requires billing to be enabled"),GrpcStatusCode.of(Status.Code.PERMISSION_DENIED),false)))
+
+      when(mockDbReader.updateDiskStatus(anyLong())).thenReturn(IO.unit)
+
+      //Act
+      val res = checker.checkResource(disk, isDryRun = false)
+      res.unsafeRunSync()
+
+      //Assert
+      verify(mockDbReader).updateDiskStatus(anyLong())
+      verify(mockGoogleDiskService).getDisk(any[GoogleProject], ZoneName(anyString()), DiskName(anyString()))(
+        any[Ask[IO, TraceId]]
+      )
+    }
+  }
 }

--- a/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
+++ b/zombie-monitor/src/test/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskCheckerSpec.scala
@@ -49,7 +49,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     checker = DeletedDiskChecker.impl(mockDbReader, mockDiskCheckerDeps)
   }
 
-  it should "call updateDiskStatus with error 'billing is disabled' (isDryRun = false)" in {
+  it should "updateDiskStatus when GCP returns a 'billing is disabled' error (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -73,7 +73,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
-  it should "not call updateDiskStatus with error 'billing is disabled'  (isDryRun = true)" in {
+  it should "not updateDiskStatus when GCP returns a 'billing is disabled' error (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -98,7 +98,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "call updateDiskStatus with error 'compute engine has not been setup' (isDryRun = false)" in {
+  it should "updateDiskStatus when GCP returns a 'compute engine has not been setup' error (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -122,7 +122,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
-  it should "not call updateDiskStatus with error 'compute engine has not been setup' (isDryRun = true)" in {
+  it should "not updateDiskStatus when GCP returns a 'compute engine has not been setup' error (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -147,7 +147,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus with unhandled error (isDryRun = false)" in {
+  it should "not updateDiskStatus when GCP returns an unhandled error (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -175,7 +175,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "call updateDiskStatus when getDisk returns no disk (isDryRun = false)" in {
+  it should "updateDiskStatus when a call to GCP's getDisk endpoint returns no disk (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -195,7 +195,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader).updateDiskStatus(disk.id)
     }
   }
-  it should "not call updateDiskStatus when getDisk returns no disk (isDryRun = true)" in {
+  it should "not updateDiskStatus when a call to GCP's getDisk endpoint returns no disk (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -216,7 +216,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
     }
   }
 
-  it should "not call updateDiskStatus when getDisk returns a disk (isDryRun = false)" in {
+  it should "not updateDiskStatus when a call to GCP's getDisk endpoint returns a disk (isDryRun = false)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()
@@ -237,7 +237,7 @@ class DeletedDiskCheckerSpec extends AnyFlatSpec with CronJobsTestSuite {
       verify(mockDbReader, never()).updateDiskStatus(disk.id)
     }
   }
-  it should "not call updateDiskStatus when getDisk returns a disk (isDryRun = true)" in {
+  it should "not updateDiskStatus when a call to GCP's getDisk endpoint returns a disk (isDryRun = true)" in {
     forAll { (disk: Disk) =>
       // Arrange
       setupMocks()


### PR DESCRIPTION
Before proceeding with changing Zombie Monitor behavior (as described [here](https://docs.google.com/document/d/1BR71eX5mWjXUoHRTYs0dMjGJe6eXa3K5sLO7neVn6So/edit)), I wanted to add some unit tests in order to verify current behavior. These will be helpful to test against when changing cron job behavior in a future ticket.