### PR TITLE
RW-12296 Changed cron job so that it no longer calls updateDiskStatus when the getDisk endpoint encounters a billing error.

### DIFF
--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -36,12 +36,12 @@ object DeletedDiskChecker {
             case Left(e) =>
               val result = e match {
                 case ee: com.google.api.gax.rpc.PermissionDeniedException =>
-                  if (
-                    ee.getCause.getMessage.contains("Compute Engine API has not been used")
-                  ) {
+                  if (ee.getCause.getMessage.contains("Compute Engine API has not been used")) {
                     if (isDryRun) F.unit else dbReader.updateDiskStatus(disk.id)
-                  } else if(ee.getCause.getMessage
-                    .contains("This API method requires billing to be enabled")){
+                  } else if (
+                    ee.getCause.getMessage
+                      .contains("This API method requires billing to be enabled")
+                  ) {
                     logger.info(s"billing is disabled for ${disk.diskName}")
                   } else logger.error(e)(s"fail to get ${disk.diskName}")
                 case e => logger.error(e)(s"fail to get ${disk.diskName}")

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -40,7 +40,7 @@ object DeletedDiskChecker {
                     ee.getCause.getMessage.contains("Compute Engine API has not been used") || ee.getCause.getMessage
                       .contains("This API method requires billing to be enabled")
                   )
-                    logger.info(s"failed to get ${disk.diskName} due to ${ee.getCause.getMessage}")
+                    logger.info(s"failed to get ${disk.diskName} due to ${ee.getCause.getMessage}") >> deps.checkRunnerDeps.metrics.incrementCounter("activeDiskBillingException")
                   else logger.error(e)(s"fail to get ${disk.diskName}")
                 case e => logger.error(e)(s"fail to get ${disk.diskName}")
               }

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -36,14 +36,12 @@ object DeletedDiskChecker {
             case Left(e) =>
               val result = e match {
                 case ee: com.google.api.gax.rpc.PermissionDeniedException =>
-                  if (ee.getCause.getMessage.contains("Compute Engine API has not been used")) {
-                    if (isDryRun) F.unit else dbReader.updateDiskStatus(disk.id)
-                  } else if (
-                    ee.getCause.getMessage
+                  if (
+                    ee.getCause.getMessage.contains("Compute Engine API has not been used") || ee.getCause.getMessage
                       .contains("This API method requires billing to be enabled")
-                  ) {
-                    logger.info(s"billing is disabled for ${disk.diskName}")
-                  } else logger.error(e)(s"fail to get ${disk.diskName}")
+                  )
+                    logger.info(s"failed to get ${disk.diskName} due to ${ee.getCause.getMessage}")
+                  else logger.error(e)(s"fail to get ${disk.diskName}")
                 case e => logger.error(e)(s"fail to get ${disk.diskName}")
               }
               result.as(Some(disk))

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -37,11 +37,13 @@ object DeletedDiskChecker {
               val result = e match {
                 case ee: com.google.api.gax.rpc.PermissionDeniedException =>
                   if (
-                    ee.getCause.getMessage.contains("Compute Engine API has not been used") || ee.getCause.getMessage
-                      .contains("This API method requires billing to be enabled")
-                  )
+                    ee.getCause.getMessage.contains("Compute Engine API has not been used")
+                  ) {
                     if (isDryRun) F.unit else dbReader.updateDiskStatus(disk.id)
-                  else logger.error(e)(s"fail to get ${disk.diskName}")
+                  } else if(ee.getCause.getMessage
+                    .contains("This API method requires billing to be enabled")){
+                    logger.info(s"billing is disabled for ${disk.diskName}")
+                  } else logger.error(e)(s"fail to get ${disk.diskName}")
                 case e => logger.error(e)(s"fail to get ${disk.diskName}")
               }
               result.as(Some(disk))

--- a/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
+++ b/zombie-monitor/src/main/scala/com/broadinstitute/dsp/zombieMonitor/DeletedDiskChecker.scala
@@ -40,7 +40,9 @@ object DeletedDiskChecker {
                     ee.getCause.getMessage.contains("Compute Engine API has not been used") || ee.getCause.getMessage
                       .contains("This API method requires billing to be enabled")
                   )
-                    logger.info(s"failed to get ${disk.diskName} due to ${ee.getCause.getMessage}") >> deps.checkRunnerDeps.metrics.incrementCounter("activeDiskBillingException")
+                    logger.info(
+                      s"failed to get ${disk.diskName} due to ${ee.getCause.getMessage}"
+                    ) >> deps.checkRunnerDeps.metrics.incrementCounter("activeDiskBillingException")
                   else logger.error(e)(s"fail to get ${disk.diskName}")
                 case e => logger.error(e)(s"fail to get ${disk.diskName}")
               }


### PR DESCRIPTION
Follow up to https://github.com/broadinstitute/leonardo-cron-jobs/pull/331. 

Behavior of this cron job is that it currently updates disk status when it encounters a PermissionDenied exception with a message that contains either “Compute Engine API has not been used” or “This API method requires billing to be enabled” and isDryRun = false.

Both of these messages will no longer update disk status.

Tested this by running `sbt "zombieMonitor/run --checkDeletedDisks"`with cloud-sql container running, so the cron job ran against dev.