### PR TITLE
RW-12864 Remove isDefault filter on nodepool

### DIFF
--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/DbReader.scala
@@ -45,7 +45,7 @@ object DbReader {
   implicit def apply[F[_]](implicit ev: DbReader[F]): DbReader[F] = ev
 
   /**
-   * Return all non-deleted GCP clusters with non-default nodepools that have apps that were all deleted
+   * Return all non-deleted GCP clusters with nodepools that have apps that were all deleted
    * or errored outside the grace period (1 hour). Note Azure Kubernetes clusters's lifecycle are managed by WSM separately. Hence
    * we don't need to check for Azure clusters.
    * We are including clusters with no nodepools and apps as well.
@@ -67,7 +67,7 @@ object DbReader {
           FROM NODEPOOL np
           RIGHT JOIN APP a ON np.id = a.nodepoolId
           WHERE
-            kc.id = np.clusterId AND np.isDefault = 0 AND
+            kc.id = np.clusterId AND
             (
               (a.status != "DELETED" AND a.status != "ERROR") OR
               (a.status = "DELETED" AND a.destroyedDate > now() - INTERVAL 1 HOUR) OR


### PR DESCRIPTION
Currently, Janitor looks for non deleted clusters that do not have users nodepools which have active apps. With autopilot, apps will "live" on default nodepools from leo's perspective, so we're updating the query to look for non deleted clusters that do not have nodepools which have active apps regardless whether the nodepool is default or not.