### PR TITLE
RW-12921 Don't add leonardo=true tag

### DIFF
--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemover.scala
@@ -46,7 +46,7 @@ object KubernetesClusterRemover {
                   if (!isDryRun && isBillingEnabled) {
                     val msg =
                       DeleteKubernetesClusterMessage(c.id, value, TraceId(s"kubernetesClusterRemover-$now"))
-                    deps.publisher.publishOne(msg, Map("leonardo" -> "true"))
+                    deps.publisher.publishOne(msg)
                   } else F.unit
                 res = if (isBillingEnabled) Some(c) else None
               } yield res

--- a/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
+++ b/janitor/src/main/scala/com/broadinstitute/dsp/janitor/NodepoolRemover.scala
@@ -41,7 +41,7 @@ object NodepoolRemover {
             n.cloudContext match {
               case CloudContext.Gcp(value) =>
                 val msg = DeleteNodepoolMessage(n.nodepoolId, value, Some(ctx))
-                val publish = if (isDryRun) F.unit else deps.publisher.publishOne(msg, Map("leonardo" -> "true"))
+                val publish = if (isDryRun) F.unit else deps.publisher.publishOne(msg)
                 publish.as(n.some)
               case CloudContext.Azure(_) =>
                 logger.warn("Azure k8s NodepoolRemover is not supported").as(none)

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/KubernetesClusterRemoverSpec.scala
@@ -37,7 +37,7 @@ final class KubernetesClusterRemoverSpec extends AnyFlatSpec with CronJobsTestSu
             IO.raiseError(fail("Shouldn't publish message in dryRun mode"))
           else {
             count = count + 1
-            super.publishOne(message, Map("leonardo" -> "true"))(evidence$2, ev)
+            super.publishOne(message)(evidence$2, ev)
           }
       }
 

--- a/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
+++ b/janitor/src/test/scala/com/broadinstitute/dsp/janitor/NodepoolRemoverSpec.scala
@@ -36,7 +36,7 @@ final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
             IO.raiseError(fail("Shouldn't publish message in dryRun mode"))
           else {
             count = count + 1
-            super.publishOne(message, Map("leonardo" -> "true"))(evidence, ev)
+            super.publishOne(message)(evidence, ev)
           }
       }
 
@@ -84,7 +84,7 @@ final class NodepoolRemoverSpec extends AnyFlatSpec with CronJobsTestSuite {
         ): IO[Unit] = {
           count = count + 1
           message shouldBe nodepoolToRemove
-          super.publishOne(message, Map("leonardo" -> "true"))(evidence, ev)
+          super.publishOne(message)(evidence, ev)
         }
       }
 

--- a/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
+++ b/resource-validator/src/main/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolChecker.scala
@@ -49,8 +49,7 @@ object DeletedOrErroredNodepoolChecker {
                     )
                     logger.warn(s"${nodepool.toString} still exists in Google. Going to delete") >> deps.publisher
                       .publishOne(
-                        msg,
-                        Map("leonardo" -> "true")
+                        msg
                       )
                   }
                 }

--- a/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
+++ b/resource-validator/src/test/scala/com/broadinstitute/dsp/resourceValidator/DeletedOrErroredNodepoolCheckerSpec.scala
@@ -41,7 +41,7 @@ class DeletedOrErroredNodepoolCheckerSpec extends AnyFlatSpec with CronJobsTestS
             IO.raiseError(fail("Shouldn't publish message in dryRun mode"))
           else {
             count = count + 1
-            super.publishOne(message, Map("leonardo" -> "true"))(evidence$2, ev)
+            super.publishOne(message)(evidence$2, ev)
           }
       }
 


### PR DESCRIPTION
`NonLeoMessageSubscriber` is supposed to process messages like deletek8sCluster...There was a recent change that `leonardo=true` is added to the msgs sent by janitor, this makes it such that `LeoPubsubSubscriber` will process these msgs instead of `NonLeoMessageSubscriber` (see [this])(https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/config/Config.scala#L846)

and as a result we see this error
```
Subscriber fail to decode message data: "{\"messageType\":\"deleteKubernetesCluster\",\"clusterId\":2178,\"project\":\"terra-vpc-sc-dev-68bb7540\",\"traceId\":\"kubernetesClusterRemover-2024-06-20T12:00:20.245464Z\"}"
attributes {
  key: "leonardo"
  value: "true"
}
message_id: "10206832210185558"
publish_time {
  seconds: 1718884820
  nanos: 509000000
}
 due to DecodingFailure(deleteKubernetesCluster is not a member of Enum (createRuntime, deleteRuntime, stopRuntime, startRuntime, updateRuntime, createDisk, updateDisk, deleteDisk, createApp, deleteApp, stopApp, startApp, updateApp, createAzureRuntime, deleteAzureRuntime, deleteDiskV2, createAppV2, deleteAppV2), List(DownField(messageType))). Going to ack the message
```

This PR fixes the bug so that NonLeoMessageSubscriber will pick up the msgs properly